### PR TITLE
Expands the maths standard library module

### DIFF
--- a/examples/syscall.stack
+++ b/examples/syscall.stack
@@ -1,6 +1,6 @@
 "std/linux-x86_64.stack" import
 
-"Hello, World!" eprintln
-1 println
+(0 0 0 0 0) tou8list stdin read
+pop eprintln
 
-;; 0 exit
+;; exit-ok

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -1189,6 +1189,30 @@ impl Program {
           }
         }
       }
+      Intrinsic::ToU8List => {
+        let item = self.pop(trace_expr)?;
+
+        match item {
+          list @ Expr::U8List(_) => {
+            self.push(list);
+            Ok(())
+          }
+          Expr::String(s) => {
+            self.push(Expr::U8List(interner().resolve(&s).as_bytes().to_vec()));
+            Ok(())
+          }
+          // TODO: Convert valid integer lists into a u8 list.
+          // Expr::List(l) => {},
+          found => Err(EvalError {
+            program: self.clone(),
+            expr: trace_expr.clone(),
+            message: format!(
+              "cannot create a u8 list from a {}",
+              found.type_of()
+            ),
+          }),
+        }
+      }
       Intrinsic::ToCall => {
         let item = self.pop(trace_expr)?;
 

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -179,10 +179,6 @@ impl Program {
             self.push(Expr::Float(lhs + rhs));
             Ok(())
           }
-          Some((Expr::Pointer(lhs), Expr::Pointer(rhs))) => {
-            self.push(Expr::Pointer(lhs + rhs));
-            Ok(())
-          }
           _ => Err(EvalError {
             expr: trace_expr.clone(),
             program: self.clone(),
@@ -208,10 +204,6 @@ impl Program {
           }
           Some((Expr::Float(lhs), Expr::Float(rhs))) => {
             self.push(Expr::Float(lhs - rhs));
-            Ok(())
-          }
-          Some((Expr::Pointer(lhs), Expr::Pointer(rhs))) => {
-            self.push(Expr::Pointer(lhs - rhs));
             Ok(())
           }
           _ => Err(EvalError {
@@ -241,10 +233,6 @@ impl Program {
             self.push(Expr::Float(lhs * rhs));
             Ok(())
           }
-          Some((Expr::Pointer(lhs), Expr::Pointer(rhs))) => {
-            self.push(Expr::Pointer(lhs * rhs));
-            Ok(())
-          }
           _ => Err(EvalError {
             expr: trace_expr.clone(),
             program: self.clone(),
@@ -272,10 +260,6 @@ impl Program {
             self.push(Expr::Float(lhs / rhs));
             Ok(())
           }
-          Some((Expr::Pointer(lhs), Expr::Pointer(rhs))) => {
-            self.push(Expr::Pointer(lhs / rhs));
-            Ok(())
-          }
           _ => Err(EvalError {
             expr: trace_expr.clone(),
             program: self.clone(),
@@ -301,10 +285,6 @@ impl Program {
           }
           Some((Expr::Float(lhs), Expr::Float(rhs))) => {
             self.push(Expr::Float(lhs % rhs));
-            Ok(())
-          }
-          Some((Expr::Pointer(lhs), Expr::Pointer(rhs))) => {
-            self.push(Expr::Pointer(lhs % rhs));
             Ok(())
           }
           _ => Err(EvalError {
@@ -481,10 +461,6 @@ impl Program {
         let args = (0..arity).try_fold(
           Vec::with_capacity(arity as usize),
           |mut args, _| match self.pop(trace_expr)? {
-            Expr::Pointer(x) => {
-              args.push(x);
-              Ok(args)
-            }
             Expr::Integer(x) => {
               if x >= 0 {
                 args.push(x as usize);
@@ -1182,33 +1158,6 @@ impl Program {
 
         Ok(())
       }
-      Intrinsic::ToPointer => {
-        let item = self.pop(trace_expr)?;
-
-        match item {
-          Expr::String(string) => {
-            let string_str = interner().resolve(&string);
-            self.push(Expr::Pointer(string_str.as_ptr() as usize));
-          }
-          found => self.push(found.to_pointer().unwrap_or(Expr::Nil)),
-        }
-
-        Ok(())
-      }
-      Intrinsic::ToList => {
-        let item = self.pop(trace_expr)?;
-
-        match item {
-          list @ Expr::List(_) => {
-            self.push(list);
-            Ok(())
-          }
-          found => {
-            self.push(Expr::List(vec![found]));
-            Ok(())
-          }
-        }
-      }
       Intrinsic::ToString => {
         let item = self.pop(trace_expr)?;
 
@@ -1222,6 +1171,20 @@ impl Program {
               Expr::String(interner().get_or_intern(found.to_string()));
             self.push(string);
 
+            Ok(())
+          }
+        }
+      }
+      Intrinsic::ToList => {
+        let item = self.pop(trace_expr)?;
+
+        match item {
+          list @ Expr::List(_) => {
+            self.push(list);
+            Ok(())
+          }
+          found => {
+            self.push(Expr::List(vec![found]));
             Ok(())
           }
         }

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -1,5 +1,4 @@
 use itertools::Itertools as _;
-// use itertools::Itertools;
 use lasso::Spur;
 use syscalls::Sysno;
 

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -582,7 +582,7 @@ impl Program {
             // TODO: Check that the length fits in an i64.
             self.push(Expr::Integer(list.len() as i64));
             Ok(())
-          },
+          }
           _ => Err(EvalError {
             expr: trace_expr.clone(),
             program: self.clone(),
@@ -727,7 +727,10 @@ impl Program {
             Ok(())
           }
           Expr::U8List(mut list) => {
-            let item = list.pop().map(|i| Expr::Integer(i as i64)).unwrap_or(Expr::Nil);
+            let item = list
+              .pop()
+              .map(|i| Expr::Integer(i as i64))
+              .unwrap_or(Expr::Nil);
 
             self.push(Expr::U8List(list));
             self.push(item);
@@ -818,7 +821,9 @@ impl Program {
             Ok(())
           }
           Expr::U8List(list) => {
-            self.stack.extend(list.into_iter().map(|i| Expr::Integer(i as i64)));
+            self
+              .stack
+              .extend(list.into_iter().map(|i| Expr::Integer(i as i64)));
             Ok(())
           }
           item => Err(EvalError {
@@ -1281,6 +1286,7 @@ impl Program {
           }
           // TODO: Convert valid integer lists into a u8 list.
           // Expr::List(l) => {},
+          // TODO: Should this return nil instead?
           found => Err(EvalError {
             program: self.clone(),
             expr: trace_expr.clone(),

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -12,8 +12,6 @@ pub enum Expr {
   Integer(i64),
   Float(f64),
 
-  Pointer(usize),
-
   String(Spur),
 
   List(Vec<Expr>),
@@ -60,8 +58,6 @@ impl Expr {
       Self::Integer(_) => Type::Integer,
       Self::Float(_) => Type::Float,
 
-      Self::Pointer(_) => Type::Pointer,
-
       Self::String(_) => Type::String,
 
       Self::List(list) => {
@@ -81,9 +77,6 @@ impl Expr {
       x @ Self::Boolean(_) => Some(x.clone()).zip(other.to_boolean()),
       x @ Self::Integer(_) => Some(x.clone()).zip(other.to_integer()),
       x @ Self::Float(_) => Some(x.clone()).zip(other.to_float()),
-
-      x @ Self::Pointer(_) => Some(x.clone()).zip(other.to_pointer()),
-
       _ => None,
     }
   }
@@ -127,14 +120,6 @@ impl Expr {
         }
       }
 
-      Self::Pointer(x) => {
-        if *x < i64::MAX as usize {
-          Some(Self::Integer(*x as i64))
-        } else {
-          None
-        }
-      }
-
       // Self::String(x) => x.parse().ok().map(Self::Integer),
       _ => None,
     }
@@ -146,25 +131,6 @@ impl Expr {
       x @ Self::Float(_) => Some(x.clone()),
 
       // Self::String(x) => x.parse().ok().map(Self::Float),
-      _ => None,
-    }
-  }
-
-  pub fn to_pointer(&self) -> Option<Self> {
-    match self {
-      // TODO: Should nil be usable as a null pointer? If so, Pointer should
-      //       store a NonZeroUsize instead.
-      Self::Nil => Some(Self::Pointer(0)),
-      Self::Integer(x) => {
-        if *x >= 0 {
-          Some(Self::Pointer(*x as usize))
-        } else {
-          None
-        }
-      }
-
-      x @ Self::Pointer(_) => Some(x.clone()),
-
       _ => None,
     }
   }
@@ -224,8 +190,6 @@ impl PartialEq for Expr {
       (Self::Integer(lhs), Self::Integer(rhs)) => lhs == rhs,
       (Self::Float(lhs), Self::Float(rhs)) => lhs == rhs,
 
-      (Self::Pointer(lhs), Self::Pointer(rhs)) => lhs == rhs,
-
       (Self::String(lhs), Self::String(rhs)) => lhs == rhs,
 
       (Self::List(lhs), Self::List(rhs)) => lhs == rhs,
@@ -254,11 +218,6 @@ impl PartialEq for Expr {
         None => false,
       },
 
-      (lhs @ Self::Pointer(_), rhs) => match rhs.to_pointer() {
-        Some(rhs) => *lhs == rhs,
-        None => false,
-      },
-
       _ => false,
     }
   }
@@ -271,8 +230,6 @@ impl PartialOrd for Expr {
       (Self::Nil, Self::Nil) => Some(Ordering::Equal),
       (Self::Integer(lhs), Self::Integer(rhs)) => lhs.partial_cmp(rhs),
       (Self::Float(lhs), Self::Float(rhs)) => lhs.partial_cmp(rhs),
-
-      (Self::Pointer(lhs), Self::Pointer(rhs)) => lhs.partial_cmp(rhs),
 
       (Self::List(lhs), Self::List(rhs)) => lhs.partial_cmp(rhs),
       (Self::String(lhs), Self::String(rhs)) => lhs.partial_cmp(rhs),
@@ -300,11 +257,6 @@ impl PartialOrd for Expr {
         None => None,
       },
 
-      (lhs @ Self::Pointer(_), rhs) => match rhs.to_pointer() {
-        Some(rhs) => lhs.partial_cmp(&rhs),
-        None => None,
-      },
-
       _ => None,
     }
   }
@@ -318,11 +270,6 @@ impl fmt::Display for Expr {
       Self::Boolean(x) => fmt::Display::fmt(x, f),
       Self::Integer(x) => fmt::Display::fmt(x, f),
       Self::Float(x) => fmt::Display::fmt(x, f),
-
-      Self::Pointer(x) => {
-        f.write_str("*")?;
-        fmt::Display::fmt(x, f)
-      }
 
       Self::String(x) => write!(f, "\"{}\"", interner().resolve(x)),
 
@@ -351,7 +298,7 @@ impl fmt::Display for Expr {
           })?;
 
         f.write_str(")")
-      },
+      }
 
       Self::Lazy(x) => {
         f.write_str("'")?;
@@ -467,8 +414,6 @@ mod test {
   #[test_case(Expr::Float(f64::NEG_INFINITY) => None)]
   #[test_case(Expr::Float(f64::INFINITY) => None)]
   #[test_case(Expr::Float(f64::NAN) => None)]
-  #[test_case(Expr::Pointer(0) => None)]
-  #[test_case(Expr::Pointer(1) => None)]
   fn to_boolean(expr: Expr) -> Option<Expr> {
     expr.to_boolean()
   }
@@ -487,8 +432,6 @@ mod test {
   #[test_case(Expr::Float(f64::NAN) => None)]
   #[test_case(Expr::Float(0.0) => Some(Expr::Integer(0)))]
   #[test_case(Expr::Float(1.0) => Some(Expr::Integer(1)))]
-  #[test_case(Expr::Pointer(0) => Some(Expr::Integer(0)))]
-  #[test_case(Expr::Pointer(1) => Some(Expr::Integer(1)))]
   fn to_integer(expr: Expr) -> Option<Expr> {
     expr.to_integer()
   }
@@ -508,29 +451,7 @@ mod test {
   // #[test_case(Expr::Float(f64::NAN) => Some(Expr::Float(f64::NAN)))]
   #[test_case(Expr::Float(0.0) => Some(Expr::Float(0.0)))]
   #[test_case(Expr::Float(1.0) => Some(Expr::Float(1.0)))]
-  #[test_case(Expr::Pointer(0) => None)]
-  #[test_case(Expr::Pointer(1) => None)]
   fn to_float(expr: Expr) -> Option<Expr> {
     expr.to_float()
-  }
-
-  #[test_case(Expr::Nil => Some(Expr::Pointer(0)))]
-  #[test_case(Expr::Boolean(false) => None)]
-  #[test_case(Expr::Boolean(true) => None)]
-  #[test_case(Expr::Integer(0) => Some(Expr::Pointer(0)))]
-  #[test_case(Expr::Integer(1) => Some(Expr::Pointer(1)))]
-  #[test_case(Expr::Integer(i64::MIN) => None)]
-  #[test_case(Expr::Integer(i64::MAX) => Some(Expr::Pointer(i64::MAX as usize)))]
-  #[test_case(Expr::Float(f64::MIN) => None)]
-  #[test_case(Expr::Float(f64::MAX) => None)]
-  #[test_case(Expr::Float(f64::NEG_INFINITY) => None)]
-  #[test_case(Expr::Float(f64::INFINITY) => None)]
-  #[test_case(Expr::Float(f64::NAN) => None)]
-  #[test_case(Expr::Float(0.0) => None)]
-  #[test_case(Expr::Float(1.0) => None)]
-  #[test_case(Expr::Pointer(0) => Some(Expr::Pointer(0)))]
-  #[test_case(Expr::Pointer(1) => Some(Expr::Pointer(1)))]
-  fn to_pointer(expr: Expr) -> Option<Expr> {
-    expr.to_pointer()
   }
 }

--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -69,6 +69,7 @@ pub enum Intrinsic {
   ToFloat,
   ToString,
   ToList,
+  ToU8List,
   ToCall,
   TypeOf,
 }
@@ -149,6 +150,7 @@ impl TryFrom<&str> for Intrinsic {
       "tofloat" => Ok(Self::ToFloat),
       "tostring" => Ok(Self::ToString),
       "tolist" => Ok(Self::ToList),
+      "tou8list" => Ok(Self::ToU8List),
       "tocall" => Ok(Self::ToCall),
       "typeof" => Ok(Self::TypeOf),
 
@@ -240,6 +242,7 @@ impl Intrinsic {
       Self::ToFloat => "tofloat",
       Self::ToString => "tostring",
       Self::ToList => "tolist",
+      Self::ToU8List => "tou8list",
       Self::ToCall => "tocall",
       Self::TypeOf => "typeof",
     }

--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -67,9 +67,8 @@ pub enum Intrinsic {
   ToBoolean,
   ToInteger,
   ToFloat,
-  ToPointer,
-  ToList,
   ToString,
+  ToList,
   ToCall,
   TypeOf,
 }
@@ -148,9 +147,8 @@ impl TryFrom<&str> for Intrinsic {
       "toboolean" => Ok(Self::ToBoolean),
       "tointeger" => Ok(Self::ToInteger),
       "tofloat" => Ok(Self::ToFloat),
-      "topointer" => Ok(Self::ToPointer),
-      "tolist" => Ok(Self::ToList),
       "tostring" => Ok(Self::ToString),
+      "tolist" => Ok(Self::ToList),
       "tocall" => Ok(Self::ToCall),
       "typeof" => Ok(Self::TypeOf),
 
@@ -240,9 +238,8 @@ impl Intrinsic {
       Self::ToBoolean => "toboolean",
       Self::ToInteger => "tointeger",
       Self::ToFloat => "tofloat",
-      Self::ToPointer => "topointer",
-      Self::ToList => "tolist",
       Self::ToString => "tostring",
+      Self::ToList => "tolist",
       Self::ToCall => "tocall",
       Self::TypeOf => "typeof",
     }

--- a/std/linux-x86_64.stack
+++ b/std/linux-x86_64.stack
@@ -1,29 +1,31 @@
 ;; See https://chromium.googlesource.com/chromiumos/docs/+/HEAD/constants/syscalls.md#x86_64-64_bit.
-;; 0 'sys-read set
+0 'sys-read set
 1 'sys-write set
-;; 2 'sys-open set
-;; 3 'sys-close set
-;; 5 'sys-fstat set
 60 'sys-exit set
 
 0 'stdin set
 1 'stdout set
 2 'stderr set
 
-;; Write a string from its parts to the file-descriptor.
-'(fn str-len str-ptr fd sys-write syscall3) '(str-len str-ptr fd) 'raw/write defn
-;; Write a string to the file-descriptor.
-'(fn str explode len str topointer fd raw/write) '(str fd) 'raw/write-str defn
+10 'newline set
 
-;; Print anything to stderr.
-'(fn any tostring stderr raw/write-str pop) '(any) 'eprint defn
-;; Print anything to stdout.
-'(fn any tostring stdout raw/write-str pop) '(any) 'print defn
+;; Write from a buffer into a file-descriptor.
+'(fn! buf tou8list dup len swap fd sys-write syscall3) '(buf fd) 'write defn
 
-;; Print anything to stderr with a newline.
-'(fn (any tostring "\n") "" join stderr raw/write-str pop) '(any) 'eprintln defn
-;; Print anything to stdout with a newline.
-'(fn (any tostring "\n") "" join stdout raw/write-str pop) '(any) 'println defn
+;; Write from a buffer into stderr.
+'(fn! buf stderr write pop pop) '(buf) 'eprint defn
+;; Write from a buffer into stdout.
+'(fn! buf stdout write pop pop) '(buf) 'print defn
 
-;; Exit the process with a code.
-'(fn code sys-exit syscall1) '(code) 'exit defn
+;; Write from a buffer into stderr with a newline.
+'(fn! buf tou8list newline insert eprint) '(buf) 'eprintln defn
+;; Write from a buffer into stdout with a newline.
+'(fn! buf tou8list newline insert print) '(buf) 'println defn
+
+;; Read into a buffer from a file-descriptor.
+'(fn! buf tou8list dup len swap fd sys-read syscall3) '(buf fd) 'read defn
+
+;; Exit the current process with a code.
+'(fn! code sys-exit syscall1) '(code) 'exit defn
+;; Exit the current process without an error code.
+'(fn! 0 exit) 'exit-ok set

--- a/std/math.stack
+++ b/std/math.stack
@@ -13,3 +13,58 @@
     ;; ( a b a b -- bool )
     > rot = or
 ) '>= set
+
+;; TODO: Figure out how to define u64 constants since they are to large to fit
+;;       in an i64.
+
+0 'u8-min set
+255 'u8-max set
+8 'u8-bits set
+
+-128 'i8-min set
+127 'i8-max set
+8 'i8-bits set
+
+0 'u16-min set
+65535 'u16-max set
+16 'u16-bits set
+
+-32768 'i16-min set
+32767 'i16-max set
+16 'i16-bits set
+
+0 'u32-min set
+4294967295 'u32-max set
+32 'u32-bits set
+
+-2147483648 'i32-min set
+2147483647 'i32-max set
+32 'i32-bits set
+
+-9223372036854775808 'i64-min set
+9223372036854775807 'i64-max set
+64 'i64-bits set
+
+;; TODO: Handle exponents in float lexical analysis to help define more
+;;       constants, as well as define nan and inf as known identifiers.
+
+1.0 0.0 / 'inf set
+-1.0 0.0 / 'neg-inf set
+0.0 0.0 / 'nan set
+2.71828182845904523536028747135266250 'euler set
+3.14159265358979323846264338327950288 'pi set
+
+;; Returns `true` if the float is NaN.
+'(fn! dup != and) 'is-nan set
+;; Returns `true` if the float is positively or negatively infinite.
+'(fn! dup inf = swap neg-inf = or and) 'is-inf set
+;; Returns `true` if the float is positively or negatively finite.
+'(fn! is-inf not) 'is-fin set
+
+;; TODO: Implement intrinsics for common float instructions, such as floor,
+;;       ceil, round, etc.
+
+;; Returns the reciprocal, inverse, of a float.
+'(fn! 1.0 swap /) 'recip set
+'(fn! 180.0 pi / *) 'to-degs set
+'(fn! pi 180.0 / *) 'to-rads set


### PR DESCRIPTION
Simply expands the constants and simple functions provided by the maths standard library module. More complex functions, such as floor, ceil, round, etc, should be added via intrinsics.

Todo:
- Decide whether to include the complex intrinsics in this PR.

Tracking:
- #6