### PR TITLE
Add more to standard maths

### DIFF
--- a/std/math.stack
+++ b/std/math.stack
@@ -13,3 +13,58 @@
     ;; ( a b a b -- bool )
     > rot = or
 ) '>= set
+
+;; TODO: Figure out how to define u64 constants since they are to large to fit
+;;       in an i64.
+
+0 'u8-min set
+255 'u8-max set
+8 'u8-bits set
+
+-128 'i8-min set
+127 'i8-max set
+8 'i8-bits set
+
+0 'u16-min set
+65535 'u16-max set
+16 'u16-bits set
+
+-32768 'i16-min set
+32767 'i16-max set
+16 'i16-bits set
+
+0 'u32-min set
+4294967295 'u32-max set
+32 'u32-bits set
+
+-2147483648 'i32-min set
+2147483647 'i32-max set
+32 'i32-bits set
+
+-9223372036854775808 'i64-min set
+9223372036854775807 'i64-max set
+64 'i64-bits set
+
+;; TODO: Handle exponents in float lexical analysis to help define more
+;;       constants, as well as define nan and inf as known identifiers.
+
+1.0 0.0 / 'inf set
+-1.0 0.0 / 'neg-inf set
+0.0 0.0 / 'nan set
+2.71828182845904523536028747135266250 'euler set
+3.14159265358979323846264338327950288 'pi set
+
+;; Returns `true` if the float is NaN.
+'(fn! dup != and) 'is-nan set
+;; Returns `true` if the float is positively or negatively infinite.
+'(fn! dup inf = swap neg-inf = or and) 'is-inf set
+;; Returns `true` if the float is positively or negatively finite.
+'(fn! is-inf not) 'is-fin set
+
+;; TODO: Implement intrinsics for common float instructions, such as floor,
+;;       ceil, round, etc.
+
+;; Returns the reciprocal, inverse, of a float.
+'(fn! 1.0 swap /) 'recip set
+'(fn! 180.0 pi / *) 'to-degs set
+'(fn! pi 180.0 / *) 'to-rads set


### PR DESCRIPTION
In the future, more complex functions, such as `round`, `floor`, `ceil`, et cetera, should be provided by intrinsics. Exponents should also be supported to make defining more floating-point constants easier.