### PR TITLE
Add new closure and scope system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,10 +96,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
+name = "bumpalo"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -142,6 +196,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +239,29 @@ checksum = "14c3242926edf34aec4ac3a77108ad4854bffaa2e4ddc1824124ce59231302d5"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fca89a0e215bab21874660c67903c5f143333cab1da83d041c7ded6053774751"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2fe95351b870527a5d09bf563ed3c97c0cffb87cf1c78a591bf48bb218d9aa"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
 ]
 
 [[package]]
@@ -184,6 +297,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "dashmap"
@@ -279,6 +398,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +427,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
 
 [[package]]
 name = "home"
@@ -329,12 +464,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itertools"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
 dependencies = [
  "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -402,6 +572,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,10 +632,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "parking_lot"
@@ -479,6 +673,34 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -510,6 +732,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,6 +759,35 @@ checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
+
+[[package]]
+name = "regex"
+version = "1.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rustix"
@@ -554,6 +825,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,6 +863,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0652c533506ad7a2e353cce269330d6afd8bdfb6d75e0ace5b35aacbd7b9e9"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -640,9 +928,10 @@ name = "stack"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "criterion",
  "crossterm",
  "enum-iterator",
- "itertools",
+ "itertools 0.12.0",
  "lasso",
  "notify",
  "rustyline",
@@ -732,6 +1021,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,6 +1075,70 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+
+[[package]]
+name = "web-sys"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,11 @@ features = ["inline-more", "multi-threaded"]
 
 [dev-dependencies]
 test-case = "3"
+criterion = "0.5.1"
+
+[[bench]]
+name = "eval"
+harness = false
 
 [[bin]]
 name = "stack"

--- a/benches/eval.rs
+++ b/benches/eval.rs
@@ -2,10 +2,16 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use stack::Program;
 
 fn cold_start_with_core() {
-  Program::new().with_core().unwrap();
+  let mut program = Program::new().with_core().unwrap();
+  program.eval_string("(2 2 + 'result def result)").unwrap();
 }
 
-fn running_code() {
+fn cold_start_no_core() {
+  let mut program = Program::new();
+  program.eval_string("(2 2 + 'result def result)").unwrap();
+}
+
+fn running_complex_code() {
   let mut program = Program::new().with_core().unwrap();
 
   program
@@ -40,7 +46,9 @@ fn criterion_benchmark(c: &mut Criterion) {
     b.iter(|| cold_start_with_core())
   });
 
-  c.bench_function("running code", |b| b.iter(|| running_code()));
+  c.bench_function("cold start no core", |b| b.iter(|| cold_start_no_core()));
+
+  c.bench_function("running code", |b| b.iter(|| running_complex_code()));
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/benches/eval.rs
+++ b/benches/eval.rs
@@ -19,20 +19,20 @@ fn running_complex_code() {
       "
   '(fn
     0 'i def
-  
+
     '(fn
       i 1 + 'i set
     ) 'inc def
-  
+
     '(fn i) 'value def
-  
+
     '()
     'inc export
     'value export
   ) 'counter def
-  
+
   counter 'my-counter use
-  
+
   my-counter/inc
   my-counter/inc
   my-counter/inc
@@ -42,13 +42,11 @@ fn running_complex_code() {
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-  c.bench_function("cold start with core", |b| {
-    b.iter(|| cold_start_with_core())
-  });
+  c.bench_function("cold start with core", |b| b.iter(cold_start_with_core));
 
-  c.bench_function("cold start no core", |b| b.iter(|| cold_start_no_core()));
+  c.bench_function("cold start no core", |b| b.iter(cold_start_no_core));
 
-  c.bench_function("running code", |b| b.iter(|| running_complex_code()));
+  c.bench_function("running code", |b| b.iter(running_complex_code));
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/benches/eval.rs
+++ b/benches/eval.rs
@@ -1,0 +1,47 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use stack::Program;
+
+fn cold_start_with_core() {
+  Program::new().with_core().unwrap();
+}
+
+fn running_code() {
+  let mut program = Program::new().with_core().unwrap();
+
+  program
+    .eval_string(
+      "
+  '(fn
+    0 'i def
+  
+    '(fn
+      i 1 + 'i set
+    ) 'inc def
+  
+    '(fn i) 'value def
+  
+    '()
+    'inc export
+    'value export
+  ) 'counter def
+  
+  counter 'my-counter use
+  
+  my-counter/inc
+  my-counter/inc
+  my-counter/inc
+  my-counter/value",
+    )
+    .unwrap();
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+  c.bench_function("cold start with core", |b| {
+    b.iter(|| cold_start_with_core())
+  });
+
+  c.bench_function("running code", |b| b.iter(|| running_code()));
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -98,6 +98,10 @@ impl<T> Chain<T> {
   pub fn root(&self) -> Rc<RefCell<T>> {
     self.value.clone()
   }
+
+  pub fn is_root(&self) -> bool {
+    self.root
+  }
 }
 
 impl<T> Chain<T>

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -82,22 +82,12 @@ impl<T> Chain<T> {
     }
   }
 
-  pub fn val(&self) -> T
-  where
-    T: Clone,
-  {
-    self.value.borrow().clone()
-  }
-
-  pub fn link(&mut self) -> Self
-  where
-    T: Clone,
-  {
-    let child = Self {
+  pub fn link(&mut self) -> Rc<RefCell<Self>> {
+    let child = Rc::new(RefCell::new(Self {
       value: self.value.clone(),
       child: None,
-    };
-    *self.child.borrow_mut() = Some(Rc::new(RefCell::new(child.clone())));
+    }));
+    *self.child.borrow_mut() = Some(child.clone());
 
     child
   }
@@ -105,28 +95,28 @@ impl<T> Chain<T> {
   pub fn root(&self) -> Rc<RefCell<T>> {
     self.value.clone()
   }
+}
 
-  pub fn unlink_with_rc(&mut self, value: Rc<RefCell<T>>)
-  where
-    T: Clone,
-  {
+impl<T> Chain<T>
+where
+  T: Clone,
+{
+  pub fn val(&self) -> T {
+    self.value.borrow().clone()
+  }
+
+  pub fn unlink_with_rc(&mut self, value: Rc<RefCell<T>>) {
     self.value = value.clone();
     if let Some(child) = &self.child {
       RefCell::borrow_mut(child).unlink_with_rc(value);
     }
   }
 
-  pub fn unlink_with(&mut self, val: T)
-  where
-    T: Clone,
-  {
+  pub fn unlink_with(&mut self, val: T) {
     self.unlink_with_rc(Rc::new(RefCell::new(val)));
   }
 
-  pub fn set(&mut self, val: T)
-  where
-    T: Clone,
-  {
+  pub fn set(&mut self, val: T) {
     *RefCell::borrow_mut(&self.value) = val;
   }
 }
@@ -148,7 +138,7 @@ mod tests {
     let link = chain.link();
 
     assert_eq!(chain.val(), 1);
-    assert_eq!(link.val(), 1);
+    assert_eq!(link.borrow().val(), 1);
   }
 
   #[test]
@@ -158,56 +148,75 @@ mod tests {
     chain.set(2);
 
     assert_eq!(chain.val(), 2);
-    assert_eq!(link.val(), 2);
+    assert_eq!(link.borrow().val(), 2);
   }
 
   #[test]
   fn change_value_with_link() {
     let mut chain = Chain::new(1);
-    let mut link = chain.link();
-    link.set(2);
+    let link = chain.link();
+    RefCell::borrow_mut(&link).set(2);
 
     assert_eq!(chain.val(), 2);
-    assert_eq!(link.val(), 2);
+    assert_eq!(link.borrow().val(), 2);
   }
 
   #[test]
   fn unlink_chain() {
     let mut a = Chain::new(1);
-    let mut b = a.link();
-    let c = b.link();
+    let b = a.link();
+    let c = RefCell::borrow_mut(&b).link();
 
     assert_eq!(a.val(), 1);
-    assert_eq!(b.val(), 1);
-    assert_eq!(c.val(), 1);
+    assert_eq!(b.borrow().val(), 1);
+    assert_eq!(c.borrow().val(), 1);
 
-    b.unlink_with(2);
+    RefCell::borrow_mut(&b).unlink_with(2);
 
     assert_eq!(a.val(), 1);
-    assert_eq!(b.val(), 2);
-    assert_eq!(c.val(), 2);
+    assert_eq!(b.borrow().val(), 2);
+    assert_eq!(c.borrow().val(), 2);
   }
 
   #[test]
   fn cloned_chains_are_links() {
     let mut a = Chain::new(1);
-    let mut b = a.link();
+    let b = a.link();
     let clone = b.clone();
 
     assert_eq!(a.val(), 1);
-    assert_eq!(b.val(), 1);
-    assert_eq!(clone.val(), 1);
+    assert_eq!(b.borrow().val(), 1);
+    assert_eq!(clone.borrow().val(), 1);
 
-    b.set(2);
-
-    assert_eq!(a.val(), 2);
-    assert_eq!(b.val(), 2);
-    assert_eq!(clone.val(), 2);
-
-    b.unlink_with(3);
+    RefCell::borrow_mut(&b).set(2);
 
     assert_eq!(a.val(), 2);
-    assert_eq!(b.val(), 3);
-    assert_eq!(clone.val(), 3);
+    assert_eq!(b.borrow().val(), 2);
+    assert_eq!(clone.borrow().val(), 2);
+
+    RefCell::borrow_mut(&b).unlink_with(3);
+
+    assert_eq!(a.val(), 2);
+    assert_eq!(b.borrow().val(), 3);
+    assert_eq!(clone.borrow().val(), 3);
+  }
+
+  #[test]
+  fn unlinked_children_dont_propagate_changes() {
+    let mut a = Chain::new(1);
+    let b = a.link();
+    let c = RefCell::borrow_mut(&b).link();
+
+    assert_eq!(a.val(), 1);
+    assert_eq!(b.borrow().val(), 1);
+    assert_eq!(c.borrow().val(), 1);
+
+    RefCell::borrow_mut(&b).unlink_with(2);
+
+    a.set(4);
+
+    assert_eq!(a.val(), 4);
+    assert_eq!(b.borrow().val(), 2);
+    assert_eq!(c.borrow().val(), 2);
   }
 }

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -1,0 +1,59 @@
+use core::cell::RefCell;
+use std::rc::Rc;
+
+#[derive(Debug, Clone)]
+pub enum Chain<T> {
+  Root(Rc<RefCell<T>>),
+  Link(Rc<RefCell<Self>>),
+}
+
+impl<T> PartialEq for Chain<T> where T: PartialEq {
+  fn eq(&self, other: &Self) -> bool {
+    RefCell::borrow(&self.root()).eq(&RefCell::borrow(&other.root()))
+  }
+}
+
+impl<T> Chain<T> {
+  #[inline]
+  pub fn new(value: T) -> Self {
+    Self::Root(Rc::new(RefCell::new(value)))
+  }
+
+  pub fn root(&self) -> Rc<RefCell<T>> {
+    match self {
+      Self::Root(root) => root.clone(),
+      Self::Link(link) => RefCell::borrow(link).root(),
+    }
+  }
+
+  pub fn link(&self) -> Self {
+    match self {
+      Self::Root(root) => {
+        Self::Link(Rc::new(RefCell::new(Self::Root(root.clone()))))
+      }
+      Self::Link(link) => {
+        Self::Link(Rc::new(RefCell::new(Self::Link(link.clone()))))
+      }
+    }
+  }
+
+  pub fn unlink_with<F>(&self, f: F)
+  where
+    F: FnOnce(&Self) -> T,
+  {
+    match self {
+      Self::Root(_) => {}
+      Self::Link(link) => *RefCell::borrow_mut(link) = Self::new(f(self)),
+    }
+  }
+}
+
+impl<T> Chain<T>
+where
+  T: Clone,
+{
+  #[inline]
+  pub fn unlink(&self) {
+    self.unlink_with(|chain| RefCell::borrow(&chain.root()).clone())
+  }
+}

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -1,73 +1,6 @@
 use core::cell::RefCell;
 use std::{borrow::BorrowMut, rc::Rc};
 
-// TODO: Look into a more efficient way to implement this.
-
-// #[derive(Debug, Clone)]
-// pub enum Chain<T> {
-//   Root(Rc<RefCell<T>>),
-//   Link(Rc<RefCell<Self>>),
-// }
-
-// impl<T> PartialEq for Chain<T>
-// where
-//   T: PartialEq,
-// {
-//   fn eq(&self, other: &Self) -> bool {
-//     RefCell::borrow(&self.root()).eq(&RefCell::borrow(&other.root()))
-//   }
-// }
-
-// impl<T> Chain<T> {
-//   #[inline]
-//   pub fn new(value: T) -> Self {
-//     Self::Root(Rc::new(RefCell::new(value)))
-//   }
-
-//   pub fn root(&self) -> Rc<RefCell<T>> {
-//     match self {
-//       Self::Root(root) => root.clone(),
-//       Self::Link(link) => RefCell::borrow(link).root(),
-//     }
-//   }
-
-//   pub fn link(&self) -> Self {
-//     match self {
-//       Self::Root(root) => {
-//         Self::Link(Rc::new(RefCell::new(Self::Root(root.clone()))))
-//       }
-//       Self::Link(link) => {
-//         Self::Link(Rc::new(RefCell::new(Self::Link(link.clone()))))
-//       }
-//     }
-//   }
-
-//   pub fn unlink_with<F>(&self, f: F)
-//   where
-//     F: FnOnce(&Self) -> T,
-//   {
-//     match self {
-//       Self::Root(_) => {}
-//       Self::Link(link) => *RefCell::borrow_mut(link) = Self::new(f(self)),
-//     }
-//   }
-// }
-
-// impl<T> Chain<T>
-// where
-//   T: Clone,
-// {
-//   #[inline]
-//   pub fn unlink(&self) {
-//     self.unlink_with(|chain| RefCell::borrow(&chain.root()).clone())
-//   }
-
-//   #[inline]
-//   pub fn val(&self) -> T {
-//     RefCell::borrow(&self.root()).clone()
-//   }
-// }
-
 #[derive(Debug, PartialEq, Clone)]
 pub struct Chain<T> {
   value: Rc<RefCell<T>>,
@@ -136,7 +69,6 @@ where
   }
 }
 
-// TODO: Add tests
 #[cfg(test)]
 mod tests {
   use super::*;

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -1,70 +1,133 @@
 use core::cell::RefCell;
-use std::rc::Rc;
+use std::{borrow::BorrowMut, rc::Rc};
 
 // TODO: Look into a more efficient way to implement this.
 
-#[derive(Debug, Clone)]
-pub enum Chain<T> {
-  Root(Rc<RefCell<T>>),
-  Link(Rc<RefCell<Self>>),
-}
+// #[derive(Debug, Clone)]
+// pub enum Chain<T> {
+//   Root(Rc<RefCell<T>>),
+//   Link(Rc<RefCell<Self>>),
+// }
 
-impl<T> PartialEq for Chain<T>
-where
-  T: PartialEq,
-{
-  fn eq(&self, other: &Self) -> bool {
-    RefCell::borrow(&self.root()).eq(&RefCell::borrow(&other.root()))
-  }
+// impl<T> PartialEq for Chain<T>
+// where
+//   T: PartialEq,
+// {
+//   fn eq(&self, other: &Self) -> bool {
+//     RefCell::borrow(&self.root()).eq(&RefCell::borrow(&other.root()))
+//   }
+// }
+
+// impl<T> Chain<T> {
+//   #[inline]
+//   pub fn new(value: T) -> Self {
+//     Self::Root(Rc::new(RefCell::new(value)))
+//   }
+
+//   pub fn root(&self) -> Rc<RefCell<T>> {
+//     match self {
+//       Self::Root(root) => root.clone(),
+//       Self::Link(link) => RefCell::borrow(link).root(),
+//     }
+//   }
+
+//   pub fn link(&self) -> Self {
+//     match self {
+//       Self::Root(root) => {
+//         Self::Link(Rc::new(RefCell::new(Self::Root(root.clone()))))
+//       }
+//       Self::Link(link) => {
+//         Self::Link(Rc::new(RefCell::new(Self::Link(link.clone()))))
+//       }
+//     }
+//   }
+
+//   pub fn unlink_with<F>(&self, f: F)
+//   where
+//     F: FnOnce(&Self) -> T,
+//   {
+//     match self {
+//       Self::Root(_) => {}
+//       Self::Link(link) => *RefCell::borrow_mut(link) = Self::new(f(self)),
+//     }
+//   }
+// }
+
+// impl<T> Chain<T>
+// where
+//   T: Clone,
+// {
+//   #[inline]
+//   pub fn unlink(&self) {
+//     self.unlink_with(|chain| RefCell::borrow(&chain.root()).clone())
+//   }
+
+//   #[inline]
+//   pub fn val(&self) -> T {
+//     RefCell::borrow(&self.root()).clone()
+//   }
+// }
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct Chain<T> {
+  value: Rc<RefCell<T>>,
+  child: Option<Rc<RefCell<Chain<T>>>>,
 }
 
 impl<T> Chain<T> {
-  #[inline]
   pub fn new(value: T) -> Self {
-    Self::Root(Rc::new(RefCell::new(value)))
+    Self {
+      value: Rc::new(RefCell::new(value)),
+      child: None,
+    }
+  }
+
+  pub fn val(&self) -> T
+  where
+    T: Clone,
+  {
+    self.value.borrow().clone()
+  }
+
+  pub fn link(&mut self) -> Self
+  where
+    T: Clone,
+  {
+    let child = Self {
+      value: self.value.clone(),
+      child: None,
+    };
+    *self.child.borrow_mut() = Some(Rc::new(RefCell::new(child.clone())));
+
+    child
   }
 
   pub fn root(&self) -> Rc<RefCell<T>> {
-    match self {
-      Self::Root(root) => root.clone(),
-      Self::Link(link) => RefCell::borrow(link).root(),
-    }
+    self.value.clone()
   }
 
-  pub fn link(&self) -> Self {
-    match self {
-      Self::Root(root) => {
-        Self::Link(Rc::new(RefCell::new(Self::Root(root.clone()))))
-      }
-      Self::Link(link) => {
-        Self::Link(Rc::new(RefCell::new(Self::Link(link.clone()))))
-      }
-    }
-  }
-
-  pub fn unlink_with<F>(&self, f: F)
+  pub fn unlink_with_rc(&mut self, value: Rc<RefCell<T>>)
   where
-    F: FnOnce(&Self) -> T,
+    T: Clone,
   {
-    match self {
-      Self::Root(_) => {}
-      Self::Link(link) => *RefCell::borrow_mut(link) = Self::new(f(self)),
+    self.value = value.clone();
+    if let Some(child) = &self.child {
+      RefCell::borrow_mut(child).unlink_with_rc(value);
     }
   }
-}
 
-impl<T> Chain<T>
-where
-  T: Clone,
-{
-  #[inline]
-  pub fn unlink(&self) {
-    self.unlink_with(|chain| RefCell::borrow(&chain.root()).clone())
+  pub fn unlink_with(&mut self, val: T)
+  where
+    T: Clone,
+  {
+    self.unlink_with_rc(Rc::new(RefCell::new(val)));
   }
 
-  #[inline]
-  pub fn val(&self) -> T {
-    RefCell::borrow(&self.root()).clone()
+  pub fn set(&mut self, val: T)
+  where
+    T: Clone,
+  {
+    *RefCell::borrow_mut(&self.value) = val;
   }
 }
 
@@ -81,7 +144,7 @@ mod tests {
 
   #[test]
   fn link_chain() {
-    let chain = Chain::new(1);
+    let mut chain = Chain::new(1);
     let link = chain.link();
 
     assert_eq!(chain.val(), 1);
@@ -90,9 +153,9 @@ mod tests {
 
   #[test]
   fn change_root_value() {
-    let chain = Chain::new(1);
+    let mut chain = Chain::new(1);
     let link = chain.link();
-    *chain.root().borrow_mut() = 2;
+    chain.set(2);
 
     assert_eq!(chain.val(), 2);
     assert_eq!(link.val(), 2);
@@ -100,9 +163,9 @@ mod tests {
 
   #[test]
   fn change_value_with_link() {
-    let chain = Chain::new(1);
-    let link = chain.link();
-    *link.root().borrow_mut() = 2;
+    let mut chain = Chain::new(1);
+    let mut link = chain.link();
+    link.set(2);
 
     assert_eq!(chain.val(), 2);
     assert_eq!(link.val(), 2);
@@ -110,15 +173,15 @@ mod tests {
 
   #[test]
   fn unlink_chain() {
-    let a = Chain::new(1);
-    let b = a.link();
+    let mut a = Chain::new(1);
+    let mut b = a.link();
     let c = b.link();
 
     assert_eq!(a.val(), 1);
     assert_eq!(b.val(), 1);
     assert_eq!(c.val(), 1);
 
-    b.unlink_with(|_| 2);
+    b.unlink_with(2);
 
     assert_eq!(a.val(), 1);
     assert_eq!(b.val(), 2);
@@ -127,21 +190,21 @@ mod tests {
 
   #[test]
   fn cloned_chains_are_links() {
-    let a = Chain::new(1);
-    let b = a.link();
+    let mut a = Chain::new(1);
+    let mut b = a.link();
     let clone = b.clone();
 
     assert_eq!(a.val(), 1);
     assert_eq!(b.val(), 1);
     assert_eq!(clone.val(), 1);
 
-    *b.root().borrow_mut() = 2;
+    b.set(2);
 
     assert_eq!(a.val(), 2);
     assert_eq!(b.val(), 2);
     assert_eq!(clone.val(), 2);
 
-    b.unlink_with(|_| 3);
+    b.unlink_with(3);
 
     assert_eq!(a.val(), 2);
     assert_eq!(b.val(), 3);

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -1,13 +1,18 @@
 use core::cell::RefCell;
 use std::rc::Rc;
 
+// TODO: Look into a more efficient way to implement this.
+
 #[derive(Debug, Clone)]
 pub enum Chain<T> {
   Root(Rc<RefCell<T>>),
   Link(Rc<RefCell<Self>>),
 }
 
-impl<T> PartialEq for Chain<T> where T: PartialEq {
+impl<T> PartialEq for Chain<T>
+where
+  T: PartialEq,
+{
   fn eq(&self, other: &Self) -> bool {
     RefCell::borrow(&self.root()).eq(&RefCell::borrow(&other.root()))
   }
@@ -57,3 +62,5 @@ where
     self.unlink_with(|chain| RefCell::borrow(&chain.root()).clone())
   }
 }
+
+// TODO: Add tests

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -61,6 +61,90 @@ where
   pub fn unlink(&self) {
     self.unlink_with(|chain| RefCell::borrow(&chain.root()).clone())
   }
+
+  #[inline]
+  pub fn val(&self) -> T {
+    RefCell::borrow(&self.root()).clone()
+  }
 }
 
 // TODO: Add tests
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn create_chain() {
+    let chain = Chain::new(1);
+    assert_eq!(chain.val(), 1);
+  }
+
+  #[test]
+  fn link_chain() {
+    let chain = Chain::new(1);
+    let link = chain.link();
+
+    assert_eq!(chain.val(), 1);
+    assert_eq!(link.val(), 1);
+  }
+
+  #[test]
+  fn change_root_value() {
+    let chain = Chain::new(1);
+    let link = chain.link();
+    *chain.root().borrow_mut() = 2;
+
+    assert_eq!(chain.val(), 2);
+    assert_eq!(link.val(), 2);
+  }
+
+  #[test]
+  fn change_value_with_link() {
+    let chain = Chain::new(1);
+    let link = chain.link();
+    *link.root().borrow_mut() = 2;
+
+    assert_eq!(chain.val(), 2);
+    assert_eq!(link.val(), 2);
+  }
+
+  #[test]
+  fn unlink_chain() {
+    let a = Chain::new(1);
+    let b = a.link();
+    let c = b.link();
+
+    assert_eq!(a.val(), 1);
+    assert_eq!(b.val(), 1);
+    assert_eq!(c.val(), 1);
+
+    b.unlink_with(|_| 2);
+
+    assert_eq!(a.val(), 1);
+    assert_eq!(b.val(), 2);
+    assert_eq!(c.val(), 2);
+  }
+
+  #[test]
+  fn cloned_chains_are_links() {
+    let a = Chain::new(1);
+    let b = a.link();
+    let clone = b.clone();
+
+    assert_eq!(a.val(), 1);
+    assert_eq!(b.val(), 1);
+    assert_eq!(clone.val(), 1);
+
+    *b.root().borrow_mut() = 2;
+
+    assert_eq!(a.val(), 2);
+    assert_eq!(b.val(), 2);
+    assert_eq!(clone.val(), 2);
+
+    b.unlink_with(|_| 3);
+
+    assert_eq!(a.val(), 2);
+    assert_eq!(b.val(), 3);
+    assert_eq!(clone.val(), 3);
+  }
+}

--- a/src/core.stack
+++ b/src/core.stack
@@ -1,26 +1,26 @@
-'(fn! read-file parse call) 'import set
-'(fn false =) 'not set
+'(fn! read-file parse call) 'import def
+'(fn false =) 'not def
 
 ;; List
 ;; ========================================
 
 ;; (list item -- 'list)
-'(fn! wrap concat) 'push set
+'(fn! wrap concat) 'push def
 ;; (list -- 'list item)
-'(fn! len 1 - split unwrap) 'pop set
+'(fn! len 1 - split unwrap) 'pop def
 
 ;; (list item -- 'list)
-'(fn! wrap swap concat) 'shift set
+'(fn! wrap swap concat) 'shift def
 ;; (list -- 'list item)
-'(fn! 1 split swap unwrap) 'unshift set
+'(fn! 1 split swap unwrap) 'unshift def
 
 ;; (list index item -- 'list)
-'(fn! rot split swap rot rot wrap concat swap concat) 'insert set
+'(fn! rot split swap rot rot wrap concat swap concat) 'insert def
 ;; (list index -- 'list item)
-'(fn! 1 + split swap pop rot swap concat swap) 'remove set
+'(fn! 1 + split swap pop rot swap concat swap) 'remove def
 
 ;; (list -- 'list)
-'(fn! () '(pop rot rot swap push) '(swap len 0 !=) while drop) 'reverse set
+'(fn! () '(pop rot rot swap push) '(swap len 0 !=) while drop) 'reverse def
 
 ;; Let
 ;; ========================================
@@ -28,12 +28,12 @@
 ;; Creates a let block
 ;; {list(fn ...) list(vars)} -> {list(fn ...)}
 '(fn
-  ['vars set]
-  ['func set]
+  ['vars def]
+  ['func def]
 
-  ['vars get len] ['var-len set drop]
+  ['vars get len] ['var-len def drop]
 
-  ['() 'new-fn set]
+  ['() 'new-fn def]
 
   ['func get]
   [unshift dup typeof]
@@ -51,7 +51,7 @@
   ["fn" =]
 ) if
 
-  [0 'i set]
+  [0 'i def]
 
   '(
     ;; Get the new function
@@ -66,8 +66,8 @@
     ;; Get the nth item, make it lazy, and insert it
     [index swap drop lazy push]
 
-    ;; Insert a `set` call
-    ['set push]
+    ;; Insert a `def` call
+    ['def push]
 
     ;; Update our new-fn
     ['new-fn set]
@@ -80,11 +80,11 @@
   ['new-fn get]
   ['func get]
   concat
-) 'let-fn set
+) 'let-fn def
 
 ;; QoL function to auto-call the created let block
 ;; {list(fn ...) list(vars)} -> {}
-'(fn! let-fn call) 'let set
+'(fn! let-fn call) 'let def
 
 ;; QoL function to set a let block to a variable
 ;; {list(fn ...) list(vars) symbol} -> {}
@@ -100,8 +100,8 @@
   ) '(func vars symbol) let
 
   ;; Setting the function to the symbol in the current scope
-  set
-) 'defn set
+  def
+) 'defn def
 
 ;; Modules
 ;; ========================================
@@ -113,7 +113,7 @@
   [swap push]
   [swap push]
   [push]
-) 'export set
+) 'export def
 
 ;; Run this function within the same scope
 '(fn!
@@ -155,7 +155,7 @@
       [tocall lazy push]
 
       ;; Push a `'set` call to the code
-      ['set push]
+      ['def push]
 
       ;; Add the code to the template function and update it
       [concat 'runner set]
@@ -172,7 +172,7 @@
 
   ;; Pop namespace
   drop
-) 'use set
+) 'use def
 
 ;; Run this function within the same scope
 '(fn!
@@ -201,10 +201,10 @@
       [pop lazy push]
 
       ;; Push a `'set` call to the code
-      ['set push]
+      ['def push]
 
       ;; Add the code to the template function and update it
-      [concat 'runner set]
+      [concat 'runner def]
 
       ;; Put the runner back on the stack
       'runner get
@@ -214,4 +214,4 @@
 
   ;; Call our template function to set all of the imported variables
   call
-) 'use-all set
+) 'use-all def

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -1656,6 +1656,8 @@ mod tests {
   }
 
   mod variables {
+    use crate::FnSymbol;
+
     use super::*;
 
     #[test]
@@ -1664,10 +1666,10 @@ mod tests {
       program.eval_string("1 'a set").unwrap();
       assert_eq!(
         program.scopes,
-        vec![HashMap::from_iter(vec![(
-          "a".to_string(),
-          Expr::Integer(1)
-        )])]
+        vec![Scope::from(HashMap::from_iter(vec![(
+          interner().get_or_intern("a"),
+          Scope::make_rc(Expr::Integer(1))
+        )]))]
       );
     }
 
@@ -1689,7 +1691,7 @@ mod tests {
     fn removing_variables() {
       let mut program = Program::new();
       program.eval_string("1 'a set 'a unset").unwrap();
-      assert_eq!(program.scopes, vec![HashMap::new()]);
+      assert_eq!(program.scopes, vec![Scope::new()]);
     }
 
     #[test]
@@ -1726,7 +1728,10 @@ mod tests {
       assert_eq!(
         program.stack,
         vec![Expr::List(vec![
-          Expr::Fn(true),
+          Expr::Fn(FnSymbol {
+            scoped: false,
+            scope: Scope::new(),
+          }),
           Expr::Integer(1),
           Expr::Integer(2),
           Expr::Call(interner().get_or_intern_static("+"))
@@ -1744,7 +1749,10 @@ mod tests {
         program.stack,
         vec![
           Expr::List(vec![
-            Expr::Fn(true),
+            Expr::Fn(FnSymbol {
+              scoped: false,
+              scope: Scope::new(),
+            }),
             Expr::Integer(1),
             Expr::Integer(2),
             Expr::Call(interner().get_or_intern_static("+"))
@@ -1770,10 +1778,10 @@ mod tests {
           .unwrap();
         assert_eq!(
           program.scopes,
-          vec![HashMap::from_iter(vec![(
-            "a".to_string(),
-            Expr::Integer(0)
-          )]),]
+          vec![Scope::from(HashMap::from_iter(vec![(
+            interner().get_or_intern("a"),
+            Scope::make_rc(Expr::Integer(0))
+          )])),]
         )
       }
 
@@ -1789,10 +1797,10 @@ mod tests {
 
         assert_eq!(
           program.scopes,
-          vec![HashMap::from_iter(vec![(
-            "a".to_string(),
-            Expr::Integer(1)
-          )]),]
+          vec![Scope::from(HashMap::from_iter(vec![(
+            interner().get_or_intern("a"),
+            Scope::make_rc(Expr::Integer(1))
+          )])),]
         )
       }
 
@@ -1808,10 +1816,10 @@ mod tests {
 
         assert_eq!(
           program.scopes,
-          vec![HashMap::from_iter(vec![(
-            "a".to_string(),
-            Expr::Integer(0)
-          )]),]
+          vec![Scope::from(HashMap::from_iter(vec![(
+            interner().get_or_intern("a"),
+            Scope::make_rc(Expr::Integer(0))
+          )])),]
         );
         assert_eq!(program.stack, vec![Expr::Integer(1), Expr::Integer(0)])
       }

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -189,9 +189,10 @@ impl Program {
     }
   }
 
+  // TODO: Make this return a result
   fn remove_scope_item(&mut self, symbol: &str) {
     if let Some(layer) = self.scopes.last_mut() {
-      layer.remove(interner().get_or_intern(symbol));
+      layer.remove(interner().get_or_intern(symbol)).unwrap();
     }
   }
 

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -141,15 +141,20 @@ impl Program {
     value: Expr,
   ) -> Result<(), EvalError> {
     if let Some(layer) = self.scopes.last_mut() {
-      // TODO: Use the error from [`Scope`]
-      layer.define(interner().get_or_intern(symbol), value);
-      Ok(())
+      match layer.define(interner().get_or_intern(symbol), value) {
+        Ok(_) => Ok(()),
+        Err(message) => Err(EvalError {
+          expr: trace_expr.clone(),
+          program: self.clone(),
+          message,
+        }),
+      }
     } else {
       Err(EvalError {
         expr: trace_expr.clone(),
         program: self.clone(),
         message: format!(
-          "no scope to define {symbol}, there may be too many \"}}\""
+          "no scope to define {symbol}"
         ),
       })
     }
@@ -162,15 +167,20 @@ impl Program {
     value: Expr,
   ) -> Result<(), EvalError> {
     if let Some(layer) = self.scopes.last_mut() {
-      // TODO: Use the error from [`Scope`]
-      layer.set(interner().get_or_intern(symbol), value);
-      Ok(())
+      match layer.set(interner().get_or_intern(symbol), value) {
+        Ok(_) => Ok(()),
+        Err(message) => Err(EvalError {
+          expr: trace_expr.clone(),
+          program: self.clone(),
+          message,
+        }),
+      }
     } else {
       Err(EvalError {
         expr: trace_expr.clone(),
         program: self.clone(),
         message: format!(
-          "no scope to set {symbol}, there may be too many \"}}\""
+          "no scope to set {symbol}"
         ),
       })
     }

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -119,7 +119,7 @@ impl Program {
     let mut scanner = Scanner::new(self.scopes.last().unwrap().clone());
     scanner.scan(expr.clone());
 
-    println!("{}: {:?}", expr, scanner.scope);
+    println!("{:#?}", scanner.scan(expr.clone()));
 
     self.stack.push(expr);
   }

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -44,18 +44,28 @@ impl fmt::Display for Program {
     if !self.scopes.is_empty() {
       writeln!(f, "Scope:")?;
 
-      let layers = self.scopes.len();
-      for (layer_i, layer) in self.scopes.iter().enumerate() {
-        let items = layer.items.len();
-        writeln!(f, "Layer {}:", layer_i)?;
-        for (item_i, (key, value)) in
-          layer.items.iter().sorted_by_key(|(s, _)| *s).enumerate()
-        {
-          if item_i == items - 1 && layer_i == layers - 1 {
-            write!(f, " + {}: {}", interner().resolve(key), value.clone().borrow())?;
-          } else {
-            writeln!(f, " + {}: {}", interner().resolve(key), value.clone().borrow())?;
-          }
+      // for (layer_i, layer) in self.scopes.iter().enumerate() {
+      //   let items = layer.items.len();
+      //   writeln!(f, "Layer {}:", layer_i)?;
+      //   for (item_i, (key, value)) in
+      //     layer.items.iter().sorted_by_key(|(s, _)| *s).enumerate()
+      //   {
+      //     if item_i == items - 1 && layer_i == layers - 1 {
+      //       write!(f, " + {}: {}", interner().resolve(key), value.clone().borrow())?;
+      //     } else {
+      //       writeln!(f, " + {}: {}", interner().resolve(key), value.clone().borrow())?;
+      //     }
+      //   }
+      // }
+      let layer = self.scopes.last().unwrap();
+      let items = layer.items.len();
+      for (item_i, (key, value)) in
+        layer.items.iter().sorted_by_key(|(s, _)| *s).enumerate()
+      {
+        if item_i == items - 1 {
+          write!(f, " + {}: {}", interner().resolve(key), value.clone().borrow())?;
+        } else {
+          writeln!(f, " + {}: {}", interner().resolve(key), value.clone().borrow())?;
         }
       }
     }

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -28,9 +28,9 @@ impl fmt::Display for Program {
 
     self.stack.iter().enumerate().try_for_each(|(i, expr)| {
       if i == self.stack.len() - 1 {
-        write!(f, "{expr}")
+        write!(f, "{}", expr)
       } else {
-        write!(f, "{expr}, ")
+        write!(f, "{}, ", expr)
       }
     })?;
     write!(f, "]")?;
@@ -44,19 +44,6 @@ impl fmt::Display for Program {
     if !self.scopes.is_empty() {
       writeln!(f, "Scope:")?;
 
-      // for (layer_i, layer) in self.scopes.iter().enumerate() {
-      //   let items = layer.items.len();
-      //   writeln!(f, "Layer {}:", layer_i)?;
-      //   for (item_i, (key, value)) in
-      //     layer.items.iter().sorted_by_key(|(s, _)| *s).enumerate()
-      //   {
-      //     if item_i == items - 1 && layer_i == layers - 1 {
-      //       write!(f, " + {}: {}", interner().resolve(key), value.clone().borrow())?;
-      //     } else {
-      //       writeln!(f, " + {}: {}", interner().resolve(key), value.clone().borrow())?;
-      //     }
-      //   }
-      // }
       let layer = self.scopes.last().unwrap();
       let items = layer.items.len();
       for (item_i, (key, value)) in

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -54,14 +54,14 @@ impl fmt::Display for Program {
             f,
             " + {}: {}",
             interner().resolve(key),
-            value.root().borrow()
+            value.borrow().val()
           )?;
         } else {
           writeln!(
             f,
             " + {}: {}",
             interner().resolve(key),
-            value.root().borrow()
+            value.borrow().val()
           )?;
         }
       }
@@ -1669,19 +1669,25 @@ mod tests {
   }
 
   mod variables {
+    use std::{cell::RefCell, rc::Rc};
+
+    use crate::Chain;
+
     use super::*;
 
     #[test]
     fn storing_variables() {
       let mut program = Program::new();
       program.eval_string("1 'a def").unwrap();
-      assert_eq!(
-        program.scopes,
-        vec![Scope::from(HashMap::from_iter(vec![(
-          interner().get_or_intern("a"),
-          Val::new(Expr::Integer(1))
-        )]))]
-      );
+
+      let a = program
+        .scopes
+        .last()
+        .unwrap()
+        .get_val(interner().get_or_intern("a"))
+        .unwrap();
+
+      assert_eq!(a, Expr::Integer(1));
     }
 
     #[test]
@@ -1789,13 +1795,15 @@ mod tests {
             '(fn 1 'a def call) call",
           )
           .unwrap();
-        assert_eq!(
-          program.scopes,
-          vec![Scope::from(HashMap::from_iter(vec![(
-            interner().get_or_intern("a"),
-            Val::new(Expr::Integer(0))
-          )])),]
-        )
+
+        let a = program
+          .scopes
+          .last()
+          .unwrap()
+          .get_val(interner().get_or_intern("a"))
+          .unwrap();
+
+        assert_eq!(a, Expr::Integer(0));
       }
 
       #[test]
@@ -1808,13 +1816,14 @@ mod tests {
           )
           .unwrap();
 
-        assert_eq!(
-          program.scopes,
-          vec![Scope::from(HashMap::from_iter(vec![(
-            interner().get_or_intern("a"),
-            Val::new(Expr::Integer(1))
-          )])),]
-        )
+        let a = program
+          .scopes
+          .last()
+          .unwrap()
+          .get_val(interner().get_or_intern("a"))
+          .unwrap();
+
+        assert_eq!(a, Expr::Integer(1));
       }
 
       #[test]
@@ -1827,13 +1836,14 @@ mod tests {
           )
           .unwrap();
 
-        assert_eq!(
-          program.scopes,
-          vec![Scope::from(HashMap::from_iter(vec![(
-            interner().get_or_intern("a"),
-            Val::new(Expr::Integer(0))
-          )])),]
-        );
+        let a = program
+          .scopes
+          .last()
+          .unwrap()
+          .get_val(interner().get_or_intern("a"))
+          .unwrap();
+
+        assert_eq!(a, Expr::Integer(0));
         assert_eq!(program.stack, vec![Expr::Integer(1), Expr::Integer(0)])
       }
     }

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -1355,7 +1355,7 @@ impl Program {
 
 #[cfg(test)]
 mod tests {
-  use crate::{FnSymbol, Val};
+  use crate::FnSymbol;
 
   use super::*;
 
@@ -1669,10 +1669,6 @@ mod tests {
   }
 
   mod variables {
-    use std::{cell::RefCell, rc::Rc};
-
-    use crate::Chain;
-
     use super::*;
 
     #[test]
@@ -1780,8 +1776,6 @@ mod tests {
     }
 
     mod scope {
-      use crate::Val;
-
       use super::*;
 
       #[test]

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -4,10 +4,18 @@ use lasso::Spur;
 
 use crate::{interner::interner, Scope};
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct FnSymbol {
   pub scoped: bool,
   pub scope: Scope,
+}
+
+impl fmt::Debug for FnSymbol {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.debug_struct("FnSymbol")
+      .field("scoped", &self.scoped)
+      .finish()
+  }
 }
 
 #[derive(Debug, Clone)]

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -79,6 +79,20 @@ impl Expr {
     }
   }
 
+  pub fn unlazy(&self) -> &Self {
+    match self {
+      Self::Lazy(x) => x.unlazy(),
+      x => x,
+    }
+  }
+
+  pub fn unlazy_mut(&mut self) -> &mut Self {
+    match self {
+      Self::Lazy(x) => x.unlazy_mut(),
+      x => x,
+    }
+  }
+
   pub fn type_of(&self) -> Type {
     match self {
       Self::Nil => Type::Nil,

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -55,7 +55,7 @@ impl Expr {
       Expr::List(list) => list
         .first()
         .and_then(|x| match x {
-          Expr::Fn(scope) => Some(true),
+          Expr::Fn(_) => Some(true),
           _ => Some(false),
         })
         .unwrap_or(false),
@@ -65,24 +65,20 @@ impl Expr {
 
   pub fn fn_symbol(&self) -> Option<&FnSymbol> {
     match self {
-      Expr::List(list) => list
-        .first()
-        .and_then(|x| match x {
-          Expr::Fn(scope) => Some(scope),
-          _ => None,
-        }),
+      Expr::List(list) => list.first().and_then(|x| match x {
+        Expr::Fn(scope) => Some(scope),
+        _ => None,
+      }),
       _ => None,
     }
   }
 
   pub fn fn_body(&self) -> Option<&[Expr]> {
     match self {
-      Expr::List(list) => list
-        .first()
-        .and_then(|x| match x {
-          Expr::Fn(_) => Some(&list[1..]),
-          _ => None,
-        }),
+      Expr::List(list) => list.first().and_then(|x| match x {
+        Expr::Fn(_) => Some(&list[1..]),
+        _ => None,
+      }),
       _ => None,
     }
   }
@@ -249,7 +245,9 @@ impl PartialEq for Expr {
       (Self::Lazy(lhs), Self::Lazy(rhs)) => lhs == rhs,
       (Self::Call(lhs), Self::Call(rhs)) => lhs == rhs,
 
-      (Self::Fn(lhs), Self::Fn(rhs)) => lhs.scope == rhs.scope && lhs.scoped == rhs.scoped,
+      (Self::Fn(lhs), Self::Fn(rhs)) => {
+        lhs.scope == rhs.scope && lhs.scoped == rhs.scoped
+      }
 
       // Different types.
       (lhs @ Self::Boolean(_), rhs) => match rhs.to_boolean() {
@@ -357,7 +355,7 @@ impl fmt::Display for Expr {
       }
       Self::Call(x) => f.write_str(interner().resolve(x)),
 
-      Self::Fn(x) => f.write_str("fn"),
+      Self::Fn(_) => f.write_str("fn"),
     }
   }
 }

--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -42,6 +42,7 @@ pub enum Intrinsic {
   Halt,
 
   // Scope
+  Def,
   Set,
   Get,
   Unset,
@@ -119,6 +120,7 @@ impl TryFrom<&str> for Intrinsic {
       "halt" => Ok(Self::Halt),
 
       // Scope
+      "def" => Ok(Self::Def),
       "set" => Ok(Self::Set),
       "get" => Ok(Self::Get),
       "unset" => Ok(Self::Unset),
@@ -207,6 +209,7 @@ impl Intrinsic {
       Self::Halt => "halt",
 
       // Scope
+      Self::Def => "def",
       Self::Set => "set",
       Self::Get => "get",
       Self::Unset => "unset",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod chain;
 mod evaluator;
 mod expr;
 mod interner;
@@ -5,12 +6,11 @@ mod intrinsics;
 mod lexer;
 mod parser;
 mod scope;
-mod chain;
 
+pub use chain::*;
 pub use evaluator::*;
 pub use expr::*;
 pub use intrinsics::*;
 pub use lexer::*;
 pub use parser::*;
 pub use scope::*;
-pub use chain::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,11 @@ mod interner;
 mod intrinsics;
 mod lexer;
 mod parser;
+mod scope;
 
 pub use evaluator::*;
 pub use expr::*;
 pub use intrinsics::*;
 pub use lexer::*;
 pub use parser::*;
+pub use scope::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod intrinsics;
 mod lexer;
 mod parser;
 mod scope;
+mod chain;
 
 pub use evaluator::*;
 pub use expr::*;
@@ -12,3 +13,4 @@ pub use intrinsics::*;
 pub use lexer::*;
 pub use parser::*;
 pub use scope::*;
+pub use chain::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,189 +1,165 @@
-// use std::fs;
-// use std::io::stdout;
-// use std::path::{Path, PathBuf};
+use std::fs;
+use std::io::stdout;
+use std::path::{Path, PathBuf};
 
-// use clap::{Parser, Subcommand};
-// use crossterm::terminal::{Clear, ClearType};
-// use crossterm::{cursor, execute};
-// use notify::event::AccessKind;
-// use notify::{
-//   Config, EventKind, INotifyWatcher, RecommendedWatcher, RecursiveMode, Watcher,
-// };
+use clap::{Parser, Subcommand};
+use crossterm::terminal::{Clear, ClearType};
+use crossterm::{cursor, execute};
+use notify::event::AccessKind;
+use notify::{
+  Config, EventKind, INotifyWatcher, RecommendedWatcher, RecursiveMode, Watcher,
+};
 
-// use rustyline::error::ReadlineError;
-// use rustyline::DefaultEditor;
-// use stack::{EvalError, Program};
+use rustyline::error::ReadlineError;
+use rustyline::DefaultEditor;
+use stack::{EvalError, Program};
 
-// #[derive(Parser)]
-// #[command(author, version, about, long_about = None)]
-// struct Cli {
-//   #[command(subcommand)]
-//   command: Option<Commands>,
-// }
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+struct Cli {
+  #[command(subcommand)]
+  command: Option<Commands>,
+}
 
-// #[derive(Subcommand)]
-// enum Commands {
-//   #[command(about = "Run a file")]
-//   Run {
-//     path: PathBuf,
+#[derive(Subcommand)]
+enum Commands {
+  #[command(about = "Run a file")]
+  Run {
+    path: PathBuf,
 
-//     #[arg(short, long)]
-//     watch: bool,
+    #[arg(short, long)]
+    watch: bool,
 
-//     #[arg(short, long)]
-//     debug: bool,
+    #[arg(short, long)]
+    debug: bool,
 
-//     #[arg(long)]
-//     no_core: bool,
-//   },
-// }
+    #[arg(long)]
+    no_core: bool,
+  },
+}
 
-// fn eval_string(program: &Program, result: Result<(), EvalError>) {
-//   println!();
-//   if let Err(err) = result {
-//     eprintln!("{}", err);
-//   } else {
-//     println!("{}", program);
-//   }
-// }
+fn eval_string(program: &Program, result: Result<(), EvalError>) {
+  println!();
+  if let Err(err) = result {
+    eprintln!("{}", err);
+  } else {
+    println!("{}", program);
+  }
+}
 
-// fn repl() -> rustyline::Result<()> {
-//   let mut rl = DefaultEditor::new()?;
-//   let mut program = Program::new().with_core().unwrap();
+fn repl() -> rustyline::Result<()> {
+  let mut rl = DefaultEditor::new()?;
+  let mut program = Program::new().with_core().unwrap();
 
-//   loop {
-//     let readline = rl.readline(">> ");
-//     match readline {
-//       Ok(line) => {
-//         rl.add_history_entry(line.as_str()).unwrap();
+  loop {
+    let readline = rl.readline(">> ");
+    match readline {
+      Ok(line) => {
+        rl.add_history_entry(line.as_str()).unwrap();
 
-//         let result = program.eval_string(line.as_str());
-//         eval_string(&program, result);
-//       }
-//       Err(ReadlineError::Interrupted) => {
-//         println!("CTRL-C");
-//         break;
-//       }
-//       Err(ReadlineError::Eof) => {
-//         println!("CTRL-D");
-//         break;
-//       }
-//       Err(err) => {
-//         println!("Error: {:?}", err);
-//         break;
-//       }
-//     }
-//   }
+        let result = program.eval_string(line.as_str());
+        eval_string(&program, result);
+      }
+      Err(ReadlineError::Interrupted) => {
+        println!("CTRL-C");
+        break;
+      }
+      Err(ReadlineError::Eof) => {
+        println!("CTRL-D");
+        break;
+      }
+      Err(err) => {
+        println!("Error: {:?}", err);
+        break;
+      }
+    }
+  }
 
-//   Ok(())
-// }
+  Ok(())
+}
 
-// fn eval_file(
-//   path: PathBuf,
-//   watcher: Option<&mut INotifyWatcher>,
-//   debug: bool,
-//   with_core: bool,
-// ) {
-//   let mut stdout = stdout();
+fn eval_file(
+  path: PathBuf,
+  watcher: Option<&mut INotifyWatcher>,
+  debug: bool,
+  with_core: bool,
+) {
+  let mut stdout = stdout();
 
-//   match fs::read(path.clone()) {
-//     Ok(contents) => {
-//       let contents = String::from_utf8(contents).unwrap();
-//       let mut program = Program::new();
+  match fs::read(path.clone()) {
+    Ok(contents) => {
+      let contents = String::from_utf8(contents).unwrap();
+      let mut program = Program::new();
 
-//       if debug {
-//         program = program.with_debug();
-//       }
+      if debug {
+        program = program.with_debug();
+      }
 
-//       if with_core {
-//         program = program.with_core().unwrap();
-//       }
+      if with_core {
+        program = program.with_core().unwrap();
+      }
 
-//       if watcher.is_some() {
-//         execute!(stdout, Clear(ClearType::All)).unwrap();
-//         execute!(stdout, cursor::MoveTo(0, 0)).unwrap();
-//       }
+      if watcher.is_some() {
+        execute!(stdout, Clear(ClearType::All)).unwrap();
+        execute!(stdout, cursor::MoveTo(0, 0)).unwrap();
+      }
 
-//       let result = program.eval_string(contents.as_str());
-//       eval_string(&program, result);
+      let result = program.eval_string(contents.as_str());
+      eval_string(&program, result);
 
-//       if let Some(watcher) = watcher {
-//         println!();
-//         println!("Watching files for changes...");
+      if let Some(watcher) = watcher {
+        println!();
+        println!("Watching files for changes...");
 
-//         println!(" - {}", path.display());
-//         for path in program.loaded_files().filter(|p| p.ends_with(".stack")) {
-//           println!(" - {}", path);
-//           watcher
-//             .watch(Path::new(path), RecursiveMode::NonRecursive)
-//             .unwrap();
-//         }
-//       }
-//     }
-//     Err(err) => {
-//       eprintln!("Error: {:?}", err);
-//     }
-//   }
-// }
-
-// fn main() {
-//   let cli = Cli::parse();
-
-//   match cli.command {
-//     Some(Commands::Run {
-//       path,
-//       watch,
-//       debug,
-//       no_core,
-//     }) => match watch {
-//       true => {
-//         let (tx, rx) = std::sync::mpsc::channel();
-
-//         let mut watcher =
-//           RecommendedWatcher::new(tx, Config::default()).unwrap();
-//         watcher.watch(&path, RecursiveMode::NonRecursive).unwrap();
-
-//         eval_file(path.clone(), Some(&mut watcher), debug, !no_core);
-//         for res in rx {
-//           match res {
-//             Ok(event) => {
-//               if let EventKind::Access(AccessKind::Close(_)) = event.kind {
-//                 eval_file(path.clone(), Some(&mut watcher), debug, !no_core);
-//               }
-//             }
-//             Err(error) => eprintln!("Error: {error:?}"),
-//           }
-//         }
-//       }
-//       false => eval_file(path, None, debug, !no_core),
-//     },
-//     None => {
-//       println!("Running REPL");
-//       repl().unwrap();
-//     }
-//   }
-// }
-
-use stack::Chain;
+        println!(" - {}", path.display());
+        for path in program.loaded_files().filter(|p| p.ends_with(".stack")) {
+          println!(" - {}", path);
+          watcher
+            .watch(Path::new(path), RecursiveMode::NonRecursive)
+            .unwrap();
+        }
+      }
+    }
+    Err(err) => {
+      eprintln!("Error: {:?}", err);
+    }
+  }
+}
 
 fn main() {
-  let mut a = Chain::new(1);
-  let mut b = a.link();
-  let c = b.link();
+  let cli = Cli::parse();
 
-  assert_eq!(a.val(), 1);
-  assert_eq!(b.val(), 1);
-  assert_eq!(c.val(), 1);
+  match cli.command {
+    Some(Commands::Run {
+      path,
+      watch,
+      debug,
+      no_core,
+    }) => match watch {
+      true => {
+        let (tx, rx) = std::sync::mpsc::channel();
 
-  b.set(2);
+        let mut watcher =
+          RecommendedWatcher::new(tx, Config::default()).unwrap();
+        watcher.watch(&path, RecursiveMode::NonRecursive).unwrap();
 
-  println!("{:?}", a);
-  println!("{:?}", b);
-  println!("{:?}", c);
-
-  b.unlink_with(3);
-
-  println!("{:?}", a);
-  println!("{:?}", b);
-  println!("{:?}", c);
+        eval_file(path.clone(), Some(&mut watcher), debug, !no_core);
+        for res in rx {
+          match res {
+            Ok(event) => {
+              if let EventKind::Access(AccessKind::Close(_)) = event.kind {
+                eval_file(path.clone(), Some(&mut watcher), debug, !no_core);
+              }
+            }
+            Err(error) => eprintln!("Error: {error:?}"),
+          }
+        }
+      }
+      false => eval_file(path, None, debug, !no_core),
+    },
+    None => {
+      println!("Running REPL");
+      repl().unwrap();
+    }
+  }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-use crate::{Expr, FnSymbol, Lexer, Span, TokenKind, TokenVec};
+use crate::{Expr, FnSymbol, Lexer, Scope, Span, TokenKind, TokenVec};
 
 /// Converts a stream of [`Token`]s into a stream of [`Expr`]s.
 ///
@@ -137,13 +137,13 @@ impl<'source> Parser<'source> {
         TokenKind::Fn => {
           break Ok(Some(Expr::Fn(FnSymbol {
             scoped: true,
-            id: None,
+            scope: Scope::new(),
           })));
         }
         TokenKind::FnExclamation => {
           break Ok(Some(Expr::Fn(FnSymbol {
             scoped: false,
-            id: None,
+            scope: Scope::new(),
           })));
         }
       }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-use crate::{Expr, Lexer, Span, TokenKind, TokenVec};
+use crate::{Expr, FnSymbol, Lexer, Span, TokenKind, TokenVec};
 
 /// Converts a stream of [`Token`]s into a stream of [`Expr`]s.
 ///
@@ -135,10 +135,16 @@ impl<'source> Parser<'source> {
           break Ok(Some(Expr::Nil));
         }
         TokenKind::Fn => {
-          break Ok(Some(Expr::Fn(true)));
+          break Ok(Some(Expr::Fn(FnSymbol {
+            scoped: true,
+            id: None,
+          })));
         }
         TokenKind::FnExclamation => {
-          break Ok(Some(Expr::Fn(false)));
+          break Ok(Some(Expr::Fn(FnSymbol {
+            scoped: false,
+            id: None,
+          })));
         }
       }
     }

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -7,7 +7,7 @@ use std::{cell::RefCell, collections::HashMap, fmt::Formatter, rc::Rc};
 
 type Val = Rc<RefCell<Expr>>;
 
-#[derive(Default, Clone)]
+#[derive(Default, Clone, PartialEq)]
 pub struct Scope {
   pub items: HashMap<Spur, Val>,
 }

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -120,3 +120,8 @@ impl Scanner {
     }
   }
 }
+
+#[cfg(test)]
+mod tests {
+  // TODO: Write tests
+}

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -1,5 +1,5 @@
 use crate::{
-  interner::interner, Expr
+  interner::interner, Expr, FnSymbol, Intrinsic
 };
 use core::fmt;
 use lasso::Spur;
@@ -59,6 +59,10 @@ impl Scope {
     Ok(())
   }
 
+  pub fn has(&self, name: Spur) -> bool {
+    self.items.contains_key(&name)
+  }
+
   pub fn get(&self, name: Spur) -> Option<Expr> {
     self.items.get(&name).map(|item| item.borrow().clone())
   }
@@ -80,18 +84,34 @@ impl Scanner {
 
   pub fn scan(&mut self, expr: Expr) -> Result<Expr, String> {
     if expr.is_function() {
-      let mut expr = expr;
+      let expr = expr;
       // We can unwrap here because we know the expression is a function
       let fn_symbol = expr.fn_symbol().unwrap();
-      let fn_body = expr.fn_body().unwrap();
+      let mut fn_body = expr.fn_body().unwrap().to_vec();
 
-      for item in fn_body {
-        if let Expr::Call(call) = item {
-          println!("Call: {}", item);
-        } else {
-          println!("Not a call: {}", item);
+      for item in fn_body.iter_mut() {
+        if let Expr::Call(call) = item.unlazy() {
+          if Intrinsic::try_from(interner().resolve(call)).is_err() {
+            if !self.scope.has(*call) {
+              self.scope.define(*call, Expr::Nil).unwrap();
+            }
+          }
+        } else if item.unlazy().is_function() {
+          let mut scanner = Scanner::new(self.scope.clone());
+          let unlazied_mut = item.unlazy_mut();
+          *unlazied_mut = scanner.scan(unlazied_mut.clone()).unwrap();
         }
       }
+
+      let fn_symbol = Expr::Fn(FnSymbol {
+        scope: self.scope.clone(),
+        scoped: fn_symbol.scoped,
+      });
+
+      let mut list_items = vec![fn_symbol];
+      list_items.extend(fn_body);
+
+      let expr = Expr::List(list_items);
 
       Ok(expr)
     } else {

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -31,6 +31,14 @@ impl Scope {
     Self::default()
   }
 
+  pub fn from(items: HashMap<Spur, Val>) -> Self {
+    Self { items }
+  }
+
+  pub fn make_rc(val: Expr) -> Val {
+    Rc::new(RefCell::new(val))
+  }
+
   pub fn define(&mut self, name: Spur, item: Expr) -> Result<(), String> {
     let item = Rc::new(RefCell::new(item));
     self.items.insert(name, item);

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -1,0 +1,102 @@
+use crate::{
+  interner::interner, Expr
+};
+use core::fmt;
+use lasso::Spur;
+use std::{cell::RefCell, collections::HashMap, fmt::Formatter, rc::Rc};
+
+type Val = Rc<RefCell<Expr>>;
+
+#[derive(Default, Clone)]
+pub struct Scope {
+  pub items: HashMap<Spur, Val>,
+}
+
+impl fmt::Debug for Scope {
+  fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    let iter = self
+      .items
+      .iter()
+      .map(|(name, item)| (interner().resolve(name), item));
+    write!(
+      f,
+      "{:?}",
+      HashMap::<&str, &Val>::from_iter(iter)
+    )
+  }
+}
+
+impl Scope {
+  pub fn new() -> Self {
+    Self::default()
+  }
+
+  pub fn define(&mut self, name: Spur, item: Expr) -> Result<(), String> {
+    let item = Rc::new(RefCell::new(item));
+    self.items.insert(name, item);
+
+    Ok(())
+  }
+
+  pub fn set(&mut self, name: Spur, item: Expr) -> Result<(), String> {
+    if let None = self.items.get(&name) {
+      return Err("Cannot set to a nonexistent variable".to_owned());
+    }
+
+    let item = Rc::new(RefCell::new(item));
+    self.items.insert(name, item);
+
+    Ok(())
+  }
+
+  pub fn remove(&mut self, name: Spur) -> Result<(), String> {
+    if let None = self.items.get(&name) {
+      return Err("Cannot remove a nonexistent variable".to_owned());
+    }
+
+    self.items.remove(&name);
+
+    Ok(())
+  }
+
+  pub fn get(&self, name: Spur) -> Option<Expr> {
+    self.items.get(&name).map(|item| item.borrow().clone())
+  }
+
+  pub fn get_ref(&self, name: Spur) -> Option<Val> {
+    self.items.get(&name).cloned()
+  }
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct Scanner {
+  pub scope: Scope,
+}
+
+impl Scanner {
+  pub fn new(scope: Scope) -> Self {
+    Self { scope }
+  }
+
+  pub fn scan(&mut self, expr: Expr) -> Result<Expr, String> {
+    if expr.is_function() {
+      let mut expr = expr;
+      // We can unwrap here because we know the expression is a function
+      let fn_symbol = expr.fn_symbol().unwrap();
+      let fn_body = expr.fn_body().unwrap();
+
+      for item in fn_body {
+        if let Expr::Call(call) = item {
+          println!("Call: {}", item);
+        } else {
+          println!("Not a call: {}", item);
+        }
+      }
+
+      Ok(expr)
+    } else {
+      // If the expression is not a function, we just return it
+      Ok(expr)
+    }
+  }
+}

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -28,7 +28,8 @@ impl Clone for Scope {
       items.insert(*name, item.clone());
     }
 
-    Self { items }
+    // Self { items }
+    todo!()
   }
 }
 
@@ -44,13 +45,14 @@ impl Scope {
   pub fn define(&mut self, name: Spur, item: Expr) -> Result<(), String> {
     if let Some(val) = self.items.get(&name) {
       match val {
-        Chain::Link(_) => {
-          val.unlink_with(|_| item);
-        }
-        Chain::Root(root) => {
-          let mut root = root.borrow_mut();
-          *root = item;
-        }
+        // Chain::Link(_) => {
+        //   val.unlink_with(|_| item);
+        // }
+        // Chain::Root(root) => {
+        //   let mut root = root.borrow_mut();
+        //   *root = item;
+        // }
+        _ => todo!(),
       }
     } else {
       let val = Val::new(item);
@@ -107,7 +109,8 @@ impl Scope {
     let mut items = HashMap::new();
 
     for (name, item) in self.items.iter() {
-      items.insert(*name, item.link());
+      // items.insert(*name, item.link());
+      todo!()
     }
 
     Self { items }

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -76,6 +76,15 @@ impl Scope {
   pub fn get_ref(&self, name: Spur) -> Option<Val> {
     self.items.get(&name).cloned()
   }
+
+  /// Merges another scope into this one, not overwriting any existing variables
+  pub fn merge(&mut self, other: Scope) {
+    for (name, item) in other.items {
+      if !self.has(name) {
+        self.items.insert(name, item);
+      }
+    }
+  }
 }
 
 #[derive(Default, Debug, Clone)]
@@ -109,8 +118,18 @@ impl Scanner {
         }
       }
 
+      let mut fn_scope = fn_symbol.scope.clone(); 
+
+      println!();
+      println!("fn before: {:?}", fn_scope.clone());
+      println!("ours before: {:?}", self.scope.clone());
+
+      fn_scope.merge(self.scope.clone());
+
+      println!("after: {:?}", fn_scope.clone());
+
       let fn_symbol = Expr::Fn(FnSymbol {
-        scope: self.scope.clone(),
+        scope: fn_scope,
         scoped: fn_symbol.scoped,
       });
 

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -39,14 +39,12 @@ impl Scope {
   }
 
   pub fn set(&mut self, name: Spur, item: Expr) -> Result<(), String> {
-    if let None = self.items.get(&name) {
-      return Err("Cannot set to a nonexistent variable".to_owned());
+    if let Some(val) = self.items.get(&name) {
+      *val.borrow_mut() = item;
+      Ok(())
+    } else {
+      Err("Cannot set to a nonexistent variable".to_owned())
     }
-
-    let item = Rc::new(RefCell::new(item));
-    self.items.insert(name, item);
-
-    Ok(())
   }
 
   pub fn remove(&mut self, name: Spur) -> Result<(), String> {

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -146,14 +146,7 @@ impl Scanner {
       }
 
       let mut fn_scope = fn_symbol.scope.clone();
-
-      println!();
-      println!("fn before: {:?}", fn_scope.clone());
-      println!("ours before: {:?}", self.scope.clone());
-
       fn_scope.merge(self.scope.clone());
-
-      println!("after: {:?}", fn_scope.clone());
 
       let fn_symbol = Expr::Fn(FnSymbol {
         scope: fn_scope,

--- a/std/assert.stack
+++ b/std/assert.stack
@@ -4,14 +4,14 @@
   '([tolist] ["assertion failed: " tolist] [swap] [concat "" join] panic)
   '(true !=)
   ifelse
-) 'assert set
+) 'assert def
 
 '(fn
-  'context set
-  'right set
-  'left set
+  'context def
+  'right def
+  'left def
 
   '('() ["assertion for [" push] [context push] ["] failed:\nLeft = " push] [left push] ["\nRight = " push] [right push] ["" join] panic)
   '(left right !=)
   if
-) 'assert-eq set
+) 'assert-eq def

--- a/std/linux-x86_64.stack
+++ b/std/linux-x86_64.stack
@@ -1,13 +1,13 @@
 ;; See https://chromium.googlesource.com/chromiumos/docs/+/HEAD/constants/syscalls.md#x86_64-64_bit.
-0 'sys-read set
-1 'sys-write set
-60 'sys-exit set
+0 'sys-read def
+1 'sys-write def
+60 'sys-exit def
 
-0 'stdin set
-1 'stdout set
-2 'stderr set
+0 'stdin def
+1 'stdout def
+2 'stderr def
 
-10 'newline set
+10 'newline def
 
 ;; Write from a buffer into a file-descriptor.
 '(fn! buf tou8list dup len swap fd sys-write syscall3) '(buf fd) 'write defn
@@ -28,4 +28,4 @@
 ;; Exit the current process with a code.
 '(fn! code sys-exit syscall1) '(code) 'exit defn
 ;; Exit the current process without an error code.
-'(fn! 0 exit) 'exit-ok set
+'(fn! 0 exit) 'exit-ok def

--- a/std/list.stack
+++ b/std/list.stack
@@ -1,12 +1,12 @@
 "std/stack.stack" import
 
 '(fn
-  0 'i set
-  ['list get len] ['length set] drop
+  0 'i def
+  ['list get len] ['length def] drop
 
-  '(fn! i length <) 'i-in-bounds set
-  '(fn! i 1 + 'i set) 'increment-i set
-  '(fn! list i index swap drop) 'get-nth set
+  '(fn! i length <) 'i-in-bounds def
+  '(fn! i 1 + 'i set) 'increment-i def
+  '(fn! list i index swap drop) 'get-nth def
 
   '(
     get-nth

--- a/std/map.stack
+++ b/std/map.stack
@@ -1,5 +1,5 @@
 '(fn
-  '() 'map/new set
+  '() 'map/new def
 
   '(fn
     '()
@@ -7,8 +7,8 @@
     ['value get push]
   ) '(key value) 'map/pair defn
 
-  '(fn 0 index swap drop) 'map/head set
-  '(fn 1 index swap drop) 'map/tail set
+  '(fn 0 index swap drop) 'map/head def
+  '(fn 1 index swap drop) 'map/tail def
 
   '(fn
     "std/list.stack" import

--- a/std/math.stack
+++ b/std/math.stack
@@ -4,7 +4,7 @@
     swap dup rot swap dup rot
     ;; ( a b a b -- bool )
     < rot = or
-) '<= set
+) '<= def
 
 ;; ( a b -- bool )
 '(fn!
@@ -12,59 +12,59 @@
     swap dup rot swap dup rot
     ;; ( a b a b -- bool )
     > rot = or
-) '>= set
+) '>= def
 
 ;; TODO: Figure out how to define u64 constants since they are to large to fit
 ;;       in an i64.
 
-0 'u8-min set
-255 'u8-max set
-8 'u8-bits set
+0 'u8-min def
+255 'u8-max def
+8 'u8-bits def
 
--128 'i8-min set
-127 'i8-max set
-8 'i8-bits set
+-128 'i8-min def
+127 'i8-max def
+8 'i8-bits def
 
-0 'u16-min set
-65535 'u16-max set
-16 'u16-bits set
+0 'u16-min def
+65535 'u16-max def
+16 'u16-bits def
 
--32768 'i16-min set
-32767 'i16-max set
-16 'i16-bits set
+-32768 'i16-min def
+32767 'i16-max def
+16 'i16-bits def
 
-0 'u32-min set
-4294967295 'u32-max set
-32 'u32-bits set
+0 'u32-min def
+4294967295 'u32-max def
+32 'u32-bits def
 
--2147483648 'i32-min set
-2147483647 'i32-max set
-32 'i32-bits set
+-2147483648 'i32-min def
+2147483647 'i32-max def
+32 'i32-bits def
 
--9223372036854775808 'i64-min set
-9223372036854775807 'i64-max set
-64 'i64-bits set
+-9223372036854775808 'i64-min def
+9223372036854775807 'i64-max def
+64 'i64-bits def
 
 ;; TODO: Handle exponents in float lexical analysis to help define more
 ;;       constants, as well as define nan and inf as known identifiers.
 
-1.0 0.0 / 'inf set
--1.0 0.0 / 'neg-inf set
-0.0 0.0 / 'nan set
-2.71828182845904523536028747135266250 'euler set
-3.14159265358979323846264338327950288 'pi set
+1.0 0.0 / 'inf def
+-1.0 0.0 / 'neg-inf def
+0.0 0.0 / 'nan def
+2.71828182845904523536028747135266250 'euler def
+3.14159265358979323846264338327950288 'pi def
 
 ;; Returns `true` if the float is NaN.
-'(fn! dup != and) 'is-nan set
+'(fn! dup != and) 'is-nan def
 ;; Returns `true` if the float is positively or negatively infinite.
-'(fn! dup inf = swap neg-inf = or and) 'is-inf set
+'(fn! dup inf = swap neg-inf = or and) 'is-inf def
 ;; Returns `true` if the float is positively or negatively finite.
-'(fn! is-inf not) 'is-fin set
+'(fn! is-inf not) 'is-fin def
 
 ;; TODO: Implement intrinsics for common float instructions, such as floor,
 ;;       ceil, round, etc.
 
 ;; Returns the reciprocal, inverse, of a float.
-'(fn! 1.0 swap /) 'recip set
-'(fn! 180.0 pi / *) 'to-degs set
-'(fn! pi 180.0 / *) 'to-rads set
+'(fn! 1.0 swap /) 'recip def
+'(fn! 180.0 pi / *) 'to-degs def
+'(fn! pi 180.0 / *) 'to-rads def

--- a/std/stack.stack
+++ b/std/stack.stack
@@ -5,4 +5,4 @@
   swap
   dup
   rot
-) 'dup2 set
+) 'dup2 def

--- a/std/type.stack
+++ b/std/type.stack
@@ -1,2 +1,2 @@
-'(fn typeof tolist 0 index swap drop "(" =) 'is-list set
-'(fn typeof tolist dup len 2 > swap 1 index swap drop "f" = =) 'is-function set
+'(fn typeof tolist 0 index swap drop "(" =) 'is-list def
+'(fn typeof tolist dup len 2 > swap 1 index swap drop "f" = =) 'is-function def

--- a/tests/example_module.stack
+++ b/tests/example_module.stack
@@ -1,8 +1,8 @@
 "std/assert.stack" import
 
 '(fn
-  0 'a set
-  1 'b set
+  0 'a def
+  1 'b def
 
   '()
   'a export
@@ -12,8 +12,8 @@
 [dup '((0 a) (1 b))] ["should export variables" assert-eq]
 
 '(fn
-  '(fn 2 +) 'add-two set
-  '(2 2 +) 'list set
+  '(fn 2 +) 'add-two def
+  '(2 2 +) 'list def
 
   '()
   'add-two export

--- a/tests/scope.stack
+++ b/tests/scope.stack
@@ -43,3 +43,13 @@ call
 
 1 "functions can use values from dead scopes (closures)" assert-eq
 i 0 "closures are isolated" assert-eq
+
+'(fn
+  0 'b def
+  
+  '(fn! 1 'b def) call
+  
+  b
+) call
+
+1 "functions! can use the current scope" assert-eq

--- a/tests/scope.stack
+++ b/tests/scope.stack
@@ -1,6 +1,15 @@
 "std/linux-x86_64.stack" import
 "std/assert.stack" import
 
+0 'var def
+var 0 "can define variables" assert-eq
+
+1 'var def
+var 1 "can redefine variables" assert-eq
+
+'(fn! 2 'var def) call
+var 2 "can redefine variables with functions!" assert-eq
+
 0 'a def
 
 '(fn

--- a/tests/scope.stack
+++ b/tests/scope.stack
@@ -13,10 +13,33 @@ add-one-to-a
 a 0 "functions create a new scope" assert-eq
 
 '(fn!
-  a 2 +
   3 'a set
 ) 'add-one-to-a! def
 
 add-one-to-a!
 
 a 3 "functions! use the current scope" assert-eq
+
+0 'i def
+'(fn
+  0 'i def
+
+  '(fn i)
+
+  '(fn
+    i 1 +
+    'i set
+  )
+)
+
+;; "Create" a counter
+call
+
+;; Call the first returned function to increment the counter
+call
+
+;; Call the second returned function to get the current value
+call
+
+1 "functions can use values from dead scopes (closures)" assert-eq
+i 0 "closures are isolated" assert-eq

--- a/tests/scope.stack
+++ b/tests/scope.stack
@@ -1,12 +1,12 @@
 "std/linux-x86_64.stack" import
 "std/assert.stack" import
 
-0 'a set
+0 'a def
 
 '(fn
   a 1 +
-  'a set
-) 'add-one-to-a set
+  'a def
+) 'add-one-to-a def
 
 add-one-to-a
 
@@ -15,7 +15,7 @@ a 0 "functions create a new scope" assert-eq
 '(fn!
   a 2 +
   3 'a set
-) 'add-one-to-a! set
+) 'add-one-to-a! def
 
 add-one-to-a!
 


### PR DESCRIPTION
This change rewrites scopes completely to scan functions at push-time, allowing them to reference values that were dropped, such as:
```clojure
'(fn 0 'a def '(fn a))

;; Call the main function
call

;; Call the function to get the value of a
call
```

Previously, once a function was executed, its scope would be dropped. If it returns any child functions that reference symbols within the parent scope, those would break.

Now, we keep those values around using magical scopes and scanning.

**PS:** Setting was also separated to be `def` and `set` where `def` defines a new variable (can be shadowed in function scopes) and `set` updates an existing variable.