### PR TITLE
Add tests for scopes

### DIFF
--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -61,14 +61,20 @@ impl fmt::Display for Program {
             f,
             " + {}: {}",
             interner().resolve(key),
-            value.borrow().val()
+            match value.borrow().val() {
+              Some(expr) => expr.to_string(),
+              None => "None".to_owned(),
+            }
           )?;
         } else {
           writeln!(
             f,
             " + {}: {}",
             interner().resolve(key),
-            value.borrow().val()
+            match value.borrow().val() {
+              Some(expr) => expr.to_string(),
+              None => "None".to_owned(),
+            }
           )?;
         }
       }

--- a/tests/objects.stack
+++ b/tests/objects.stack
@@ -1,0 +1,24 @@
+"std/assert.stack" import
+
+'(fn
+  0 'i def
+
+  '(fn
+    i 1 + 'i set
+  ) 'inc def
+
+  '(fn i) 'value def
+
+  '()
+  'inc export
+  'value export
+) 'counter def
+
+counter 'my-counter use
+
+my-counter/inc
+my-counter/inc
+my-counter/inc
+my-counter/value
+
+3 "closures and objects should be mutable" assert-eq


### PR DESCRIPTION
1. Added much needed tests for scopes
2. Added an in-language test file
3. Updated scopes to initialize variables to `None` instead of a `Expr::Nil` (will throw if the variable isn't then set).