### PR TITLE
Add a userdata expression

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: Version
+        run: rustc --version
       - name: Build
         run: cargo build --verbose
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,8 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Version
-        run: rustc --version
+      - name: Update Rust
+        run: rustup update
       - name: Build
         run: cargo build --verbose
       - name: Run tests

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1,4 +1,5 @@
-use core::{cmp::Ordering, fmt, iter, num::FpCategory};
+use core::{any::Any, cmp::Ordering, fmt, iter, num::FpCategory};
+use std::rc::Rc;
 
 use lasso::Spur;
 
@@ -34,6 +35,8 @@ pub enum Expr {
 
   /// Boolean denotes whether to create a new scope.
   Fn(FnSymbol),
+
+  UserData(Rc<dyn Any>),
 }
 
 impl Expr {
@@ -110,6 +113,8 @@ impl Expr {
       Self::Call(_) => Type::Call,
 
       Self::Fn(_) => Type::FnScope,
+
+      Self::UserData(_) => Type::UserData,
     }
   }
 
@@ -337,6 +342,8 @@ impl fmt::Display for Expr {
       Self::Call(x) => f.write_str(interner().resolve(x)),
 
       Self::Fn(_) => f.write_str("fn"),
+
+      Self::UserData(_) => f.write_str("userdata"),
     }
   }
 }
@@ -363,6 +370,8 @@ pub enum Type {
 
   Any,
   Set(Vec<Self>),
+
+  UserData,
 }
 
 impl fmt::Display for Type {
@@ -412,6 +421,8 @@ impl fmt::Display for Type {
 
         f.write_str("]")
       }
+
+      Self::UserData => f.write_str("userdata"),
     }
   }
 }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -248,6 +248,8 @@ impl PartialEq for Expr {
       // Though, I think there's a better solution than removing comparability.
       (Self::Fn(lhs), Self::Fn(rhs)) => lhs.scoped == rhs.scoped,
 
+      (Self::UserData(lhs), Self::UserData(rhs)) => core::ptr::addr_eq(Rc::as_ptr(lhs), Rc::as_ptr(rhs)),
+
       // Different types.
       (lhs @ Self::Boolean(_), rhs) => match rhs.to_boolean() {
         Some(rhs) => *lhs == rhs,

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1,4 +1,4 @@
-use core::{any::Any, cmp::Ordering, fmt, iter, num::FpCategory};
+use core::{any::Any, cell::RefCell, cmp::Ordering, fmt, iter, num::FpCategory};
 use std::rc::Rc;
 
 use lasso::Spur;
@@ -36,7 +36,7 @@ pub enum Expr {
   /// Boolean denotes whether to create a new scope.
   Fn(FnSymbol),
 
-  UserData(Rc<dyn Any>),
+  UserData(Rc<RefCell<dyn Any>>),
 }
 
 impl Expr {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use notify::{
 
 use rustyline::error::ReadlineError;
 use rustyline::DefaultEditor;
-use stack::{EvalError, Program};
+use stack::{map, EvalError, Program};
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -52,7 +52,7 @@ fn repl(with_core: bool) -> rustyline::Result<()> {
   let mut program = Program::new();
 
   if with_core {
-    program = program.with_core().unwrap();
+    program = program.with_core().unwrap().with_module(map::module).unwrap();
   }
 
   loop {
@@ -100,7 +100,7 @@ fn eval_file(
       }
 
       if with_core {
-        program = program.with_core().unwrap();
+        program = program.with_core().unwrap().with_module(map::module).unwrap();
       }
 
       if watcher.is_some() {

--- a/src/module/map.rs
+++ b/src/module/map.rs
@@ -1,0 +1,130 @@
+use core::cell::RefCell;
+use std::{collections::HashMap, rc::Rc};
+
+use lasso::Spur;
+
+use crate::{interner::interner, EvalError, Expr, Program};
+
+pub fn module(program: &mut Program) -> Result<(), EvalError> {
+  program.funcs.insert(
+    interner().get_or_intern_static("map/new"),
+    |program, _| {
+      program.push(Expr::UserData(Rc::new(RefCell::new(HashMap::<Spur, Expr>::new()))));
+      Ok(())
+    },
+  );
+
+  program.funcs.insert(
+    interner().get_or_intern_static("map/insert"),
+    |program, trace_expr| {
+      let key = program.pop(trace_expr)?;
+      let item = program.pop(trace_expr)?;
+      let map = program.pop(trace_expr)?;
+
+      program.push(map.clone());
+
+      match map {
+        Expr::UserData(map) => match map.borrow_mut().downcast_mut::<HashMap<Spur, Expr>>() {
+          Some(map) => match key {
+            Expr::Call(key) | Expr::String(key) => {
+              map.insert(key, item);
+            },
+            found => return Err(EvalError {
+              program: program.clone(),
+              expr: trace_expr.clone(),
+              message: format!("expected call or string, found {}", found.type_of()),
+            }),
+          },
+          None => return Err(EvalError {
+            program: program.clone(),
+            expr: trace_expr.clone(),
+            message: "unable to downcast userdata into map".into(),
+          })
+        },
+        found => return Err(EvalError {
+          program: program.clone(),
+          expr: trace_expr.clone(),
+          message: format!("expected userdata, found {}", found.type_of()),
+        }),
+      }
+
+      Ok(())
+    },
+  );
+
+  program.funcs.insert(
+    interner().get_or_intern_static("map/remove"),
+    |program, trace_expr| {
+      let key = program.pop(trace_expr)?;
+      let map = program.pop(trace_expr)?;
+
+      program.push(map.clone());
+
+      match map {
+        Expr::UserData(map) => match map.borrow_mut().downcast_mut::<HashMap<Spur, Expr>>() {
+            Some(map) => match key {
+              Expr::Call(ref key) | Expr::String(ref key) => {
+                map.remove(key);
+              },
+              found => return Err(EvalError {
+                program: program.clone(),
+                expr: trace_expr.clone(),
+                message: format!("expected call or string, found {}", found.type_of()),
+              }),
+            },
+            None => return Err(EvalError {
+              program: program.clone(),
+              expr: trace_expr.clone(),
+              message: "unable to downcast userdata into map".into(),
+            })
+          },
+        found => return Err(EvalError {
+          program: program.clone(),
+          expr: trace_expr.clone(),
+          message: format!("expected userdata, found {}", found.type_of()),
+        }),
+      }
+
+      Ok(())
+    },
+  );
+
+  program.funcs.insert(
+    interner().get_or_intern_static("map/get"),
+    |program, trace_expr| {
+      let key = program.pop(trace_expr)?;
+      let map = program.pop(trace_expr)?;
+
+      program.push(map.clone());
+
+      match map {
+        Expr::UserData(map) => match map.borrow().downcast_ref::<HashMap<Spur, Expr>>() {
+          Some(map) => match key {
+            Expr::Call(ref key) | Expr::String(ref key) => {
+              program.push(map.get(key).cloned().unwrap_or(Expr::Nil));
+            },
+            found => return Err(EvalError {
+              program: program.clone(),
+              expr: trace_expr.clone(),
+              message: format!("expected call or string, found {}", found.type_of()),
+            }),
+          },
+          None => return Err(EvalError {
+            program: program.clone(),
+            expr: trace_expr.clone(),
+            message: "unable to downcast userdata into map".into(),
+          })
+        },
+        found => return Err(EvalError {
+          program: program.clone(),
+          expr: trace_expr.clone(),
+          message: format!("expected userdata, found {}", found.type_of()),
+        }),
+      }
+
+      Ok(())
+    },
+  );
+
+  Ok(())
+}

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -1,4 +1,5 @@
 pub mod core;
+pub mod map;
 
 use crate::{EvalError, Expr, Program};
 

--- a/tests/_runner.rs
+++ b/tests/_runner.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use stack::Program;
+use stack::{map, Program};
 
 #[test]
 fn run_tests() {
@@ -14,7 +14,7 @@ fn run_tests() {
       if name.to_str().unwrap().ends_with(".stack") {
         let contents = fs::read_to_string(&path).unwrap();
 
-        let mut program = Program::new().with_core().unwrap();
+        let mut program = Program::new().with_core().unwrap().with_module(map::module).unwrap();
         let result = program.eval_string(contents.as_str());
 
         assert!(

--- a/tests/map.stack
+++ b/tests/map.stack
@@ -1,9 +1,19 @@
-;; "std/assert.stack" import
-;; ["std/map.stack" import use-all]
+"std/assert.stack" import
 
-;; '()
-;; ['a 1 map/pair] map/insert
-;; ['b 2 map/pair] map/insert
+map/new
 
-;; [dup 'a map/has] ["map has a" assert]
-;; ['c map/has] [not "map doesn't have c" assert]
+'a map/get nil "new" assert-eq
+
+1 'a map/insert
+'a map/get 1 "inserted a 1" assert-eq
+
+2 'b map/insert
+'b map/get 2 "inserted b 2" assert-eq
+
+'a map/remove
+'a map/get nil "removed a" assert-eq
+'b map/get 2 "exists b" assert-eq
+
+drop
+
+collect len 0 "stuff left over" assert-eq


### PR DESCRIPTION
This allows modules to provide opaque data to the language, which can be downcast by native functions and used. See `stack::module::map` for an example.