### PR TITLE
A bit of clean up and improvements

### DIFF
--- a/stack-core/src/engine.rs
+++ b/stack-core/src/engine.rs
@@ -115,10 +115,9 @@ impl Engine {
             }
             Ok(context)
           } else {
-            context.stack_push(Expr {
-              kind: ExprKind::Error(Error::new("unknown function".into())),
-              info: None,
-            })?;
+            context.stack_push(
+              ExprKind::Error(Error::new("unknown function".into())).into(),
+            )?;
 
             Ok(context)
           }

--- a/stack-core/src/expr.rs
+++ b/stack-core/src/expr.rs
@@ -299,10 +299,7 @@ impl fmt::Display for ExprKind {
             .chain(core::iter::repeat(", "))
             .zip(x.iter())
             .try_for_each(|(sep, (key, value))| {
-              let key = Expr {
-                info: None,
-                kind: ExprKind::Symbol(*key),
-              };
+              let key: Expr = ExprKind::Symbol(*key).into();
               write!(f, "{sep}{key:#}: {value:#}")
             })?;
 

--- a/stack-core/src/expr.rs
+++ b/stack-core/src/expr.rs
@@ -117,6 +117,26 @@ impl ExprKind {
       x => x,
     }
   }
+
+  pub fn type_of(&self) -> &str {
+    match self {
+      ExprKind::Nil => "nil",
+      ExprKind::Error(_) => "error",
+
+      ExprKind::Boolean(_) => "boolean",
+      ExprKind::Integer(_) => "integer",
+      ExprKind::Float(_) => "float",
+      ExprKind::String(_) => "string",
+
+      ExprKind::Symbol(_) => "symbol",
+
+      ExprKind::Lazy(_) => "lazy",
+      ExprKind::List(_) => "list",
+      ExprKind::Record(_) => "record",
+
+      ExprKind::Fn(_) => "function",
+    }
+  }
 }
 
 impl PartialEq for ExprKind {

--- a/stack-core/src/expr.rs
+++ b/stack-core/src/expr.rs
@@ -13,6 +13,15 @@ pub struct Expr {
   pub info: Option<ExprInfo>,
 }
 
+impl From<ExprKind> for Expr {
+  fn from(value: ExprKind) -> Self {
+    Self {
+      info: None,
+      kind: value,
+    }
+  }
+}
+
 impl PartialEq for Expr {
   #[inline]
   fn eq(&self, other: &Self) -> bool {

--- a/stack-core/src/intrinsic.rs
+++ b/stack-core/src/intrinsic.rs
@@ -128,7 +128,7 @@ impl Intrinsic {
           Err(_) => ExprKind::Nil,
         };
 
-        context.stack_push(Expr { kind, info: None })?;
+        context.stack_push(kind.into())?;
 
         Ok(context)
       }
@@ -142,7 +142,7 @@ impl Intrinsic {
           Err(_) => ExprKind::Nil,
         };
 
-        context.stack_push(Expr { kind, info: None })?;
+        context.stack_push(kind.into())?;
 
         Ok(context)
       }
@@ -156,7 +156,7 @@ impl Intrinsic {
           Err(_) => ExprKind::Nil,
         };
 
-        context.stack_push(Expr { kind, info: None })?;
+        context.stack_push(kind.into())?;
 
         Ok(context)
       }
@@ -170,7 +170,7 @@ impl Intrinsic {
           Err(_) => ExprKind::Nil,
         };
 
-        context.stack_push(Expr { kind, info: None })?;
+        context.stack_push(kind.into())?;
 
         Ok(context)
       }
@@ -184,7 +184,7 @@ impl Intrinsic {
           Err(_) => ExprKind::Nil,
         };
 
-        context.stack_push(Expr { kind, info: None })?;
+        context.stack_push(kind.into())?;
 
         Ok(context)
       }
@@ -196,7 +196,7 @@ impl Intrinsic {
 
         let kind = ExprKind::Boolean(lhs.kind == rhs.kind);
 
-        context.stack_push(Expr { kind, info: None })?;
+        context.stack_push(kind.into())?;
 
         Ok(context)
       }
@@ -207,7 +207,7 @@ impl Intrinsic {
 
         let kind = ExprKind::Boolean(lhs.kind != rhs.kind);
 
-        context.stack_push(Expr { kind, info: None })?;
+        context.stack_push(kind.into())?;
 
         Ok(context)
       }
@@ -218,7 +218,7 @@ impl Intrinsic {
 
         let kind = ExprKind::Boolean(lhs.kind < rhs.kind);
 
-        context.stack_push(Expr { kind, info: None })?;
+        context.stack_push(kind.into())?;
 
         Ok(context)
       }
@@ -229,7 +229,7 @@ impl Intrinsic {
 
         let kind = ExprKind::Boolean(lhs.kind <= rhs.kind);
 
-        context.stack_push(Expr { kind, info: None })?;
+        context.stack_push(kind.into())?;
 
         Ok(context)
       }
@@ -240,7 +240,7 @@ impl Intrinsic {
 
         let kind = ExprKind::Boolean(lhs.kind > rhs.kind);
 
-        context.stack_push(Expr { kind, info: None })?;
+        context.stack_push(kind.into())?;
 
         Ok(context)
       }
@@ -251,7 +251,7 @@ impl Intrinsic {
 
         let kind = ExprKind::Boolean(lhs.kind >= rhs.kind);
 
-        context.stack_push(Expr { kind, info: None })?;
+        context.stack_push(kind.into())?;
 
         Ok(context)
       }
@@ -264,7 +264,7 @@ impl Intrinsic {
         let kind =
           ExprKind::Boolean(lhs.kind.is_truthy() || rhs.kind.is_truthy());
 
-        context.stack_push(Expr { kind, info: None })?;
+        context.stack_push(kind.into())?;
 
         Ok(context)
       }
@@ -276,7 +276,7 @@ impl Intrinsic {
         let kind =
           ExprKind::Boolean(lhs.kind.is_truthy() && rhs.kind.is_truthy());
 
-        context.stack_push(Expr { kind, info: None })?;
+        context.stack_push(kind.into())?;
 
         Ok(context)
       }
@@ -286,7 +286,7 @@ impl Intrinsic {
 
         let kind = ExprKind::Boolean(!rhs.kind.is_truthy());
 
-        context.stack_push(Expr { kind, info: None })?;
+        context.stack_push(kind.into())?;
 
         Ok(context)
       }
@@ -302,10 +302,7 @@ impl Intrinsic {
           Err(RunError {
             reason: RunErrorReason::AssertionFailed,
             context,
-            expr: Expr {
-              info: None,
-              kind: message.kind,
-            },
+            expr: message.kind.into(),
           })
         }
       }
@@ -382,7 +379,7 @@ impl Intrinsic {
 
         context.stack_push(item.clone())?;
 
-        context.stack_push(Expr { kind, info: None })?;
+        context.stack_push(kind.into())?;
 
         Ok(context)
       }
@@ -408,7 +405,7 @@ impl Intrinsic {
 
         context.stack_push(item.clone())?;
 
-        context.stack_push(Expr { kind, info: None })?;
+        context.stack_push(kind.into())?;
 
         Ok(context)
       }
@@ -423,25 +420,13 @@ impl Intrinsic {
             if (i as usize) < x.len() {
               let rest = x.split_off(i as usize);
 
-              context.stack_push(Expr {
-                kind: ExprKind::List(x),
-                info: None,
-              })?;
+              context.stack_push(ExprKind::List(x).into())?;
 
-              context.stack_push(Expr {
-                kind: ExprKind::List(rest),
-                info: None,
-              })?;
+              context.stack_push(ExprKind::List(rest).into())?;
             } else {
-              context.stack_push(Expr {
-                kind: ExprKind::List(x),
-                info: None,
-              })?;
+              context.stack_push(ExprKind::List(x).into())?;
 
-              context.stack_push(Expr {
-                kind: ExprKind::Nil,
-                info: None,
-              })?;
+              context.stack_push(ExprKind::Nil.into())?;
             }
           }
           (ExprKind::String(mut x), ExprKind::Integer(i)) if i >= 0 => {
@@ -449,39 +434,21 @@ impl Intrinsic {
               Some((i, _)) => {
                 let rest = x.split_off(i);
 
-                context.stack_push(Expr {
-                  kind: ExprKind::String(x),
-                  info: None,
-                })?;
+                context.stack_push(ExprKind::String(x).into())?;
 
-                context.stack_push(Expr {
-                  kind: ExprKind::String(rest),
-                  info: None,
-                })?;
+                context.stack_push(ExprKind::String(rest).into())?;
               }
               None => {
-                context.stack_push(Expr {
-                  kind: ExprKind::String(x),
-                  info: None,
-                })?;
+                context.stack_push(ExprKind::String(x).into())?;
 
-                context.stack_push(Expr {
-                  kind: ExprKind::Nil,
-                  info: None,
-                })?;
+                context.stack_push(ExprKind::Nil.into())?;
               }
             }
           }
           _ => {
-            context.stack_push(Expr {
-              kind: ExprKind::Nil,
-              info: None,
-            })?;
+            context.stack_push(ExprKind::Nil.into())?;
 
-            context.stack_push(Expr {
-              kind: ExprKind::Nil,
-              info: None,
-            })?;
+            context.stack_push(ExprKind::Nil.into())?;
           }
         }
 
@@ -505,7 +472,7 @@ impl Intrinsic {
           _ => ExprKind::Nil,
         };
 
-        context.stack_push(Expr { kind, info: None })?;
+        context.stack_push(kind.into())?;
 
         Ok(context)
       }
@@ -539,7 +506,7 @@ impl Intrinsic {
           _ => ExprKind::Nil,
         };
 
-        context.stack_push(Expr { kind, info: None })?;
+        context.stack_push(kind.into())?;
 
         Ok(context)
       }
@@ -549,41 +516,23 @@ impl Intrinsic {
 
         match list.kind.clone() {
           ExprKind::List(mut x) => {
-            let e = x.pop().unwrap_or(Expr {
-              kind: ExprKind::Nil,
-              info: None,
-            });
+            let e = x.pop().unwrap_or(ExprKind::Nil.into());
 
-            context.stack_push(Expr {
-              kind: ExprKind::List(x),
-              info: list.info,
-            })?;
+            context.stack_push(ExprKind::List(x).into())?;
             context.stack_push(e)?;
           }
           ExprKind::String(mut x) => {
             let e = x
               .pop()
-              .map(|e| Expr {
-                kind: ExprKind::String(e.to_compact_string()),
-                info: None,
-              })
-              .unwrap_or(Expr {
-                kind: ExprKind::Nil,
-                info: None,
-              });
+              .map(|e| ExprKind::String(e.to_compact_string()).into())
+              .unwrap_or(ExprKind::Nil.into());
 
-            context.stack_push(Expr {
-              kind: ExprKind::String(x),
-              info: list.info,
-            })?;
+            context.stack_push(ExprKind::String(x).into())?;
             context.stack_push(e)?;
           }
           _ => {
             context.stack_push(list.clone())?;
-            context.stack_push(Expr {
-              kind: ExprKind::Nil,
-              info: None,
-            })?;
+            context.stack_push(ExprKind::Nil.into())?;
           }
         }
 
@@ -885,7 +834,7 @@ impl Intrinsic {
           _ => ExprKind::Nil,
         };
 
-        context.stack_push(Expr { kind, info: None })?;
+        context.stack_push(kind.into())?;
 
         Ok(context)
       }
@@ -894,10 +843,7 @@ impl Intrinsic {
       Self::Lazy => {
         let expr = context.stack_pop(&expr)?;
 
-        context.stack_push(Expr {
-          kind: ExprKind::Lazy(Box::new(expr)),
-          info: None,
-        })?;
+        context.stack_push(ExprKind::Lazy(Box::new(expr)).into())?;
 
         Ok(context)
       }
@@ -1055,10 +1001,8 @@ impl Intrinsic {
       // MARK: Recur
       // Functionality is implemented in [`Engine::call_fn`]
       Self::Recur => {
-        context.stack_push(Expr {
-          kind: ExprKind::Symbol(Symbol::from_ref("recur")),
-          info: None,
-        })?;
+        context
+          .stack_push(ExprKind::Symbol(Symbol::from_ref("recur")).into())?;
 
         Ok(context)
       }

--- a/stack-core/src/intrinsic.rs
+++ b/stack-core/src/intrinsic.rs
@@ -550,17 +550,11 @@ impl Intrinsic {
             let mut new_record = record.clone();
             new_record.insert(symbol, value);
 
-            context.stack_push(Expr {
-              kind: ExprKind::Record(new_record),
-              info: None,
-            })?;
+            context.stack_push(ExprKind::Record(new_record).into())?;
 
             Ok(())
           }
-          _ => context.stack_push(Expr {
-            kind: ExprKind::Nil,
-            info: None,
-          }),
+          _ => context.stack_push(ExprKind::Nil.into()),
         }
         .map(|_| context)
       }
@@ -583,10 +577,7 @@ impl Intrinsic {
 
             Ok(())
           }
-          _ => context.stack_push(Expr {
-            kind: ExprKind::Nil,
-            info: None,
-          }),
+          _ => context.stack_push(ExprKind::Nil.into()),
         }
         .map(|_| context)
       }
@@ -602,17 +593,11 @@ impl Intrinsic {
             let result = r.contains_key(&symbol);
 
             context.stack_push(record.clone())?;
-            context.stack_push(Expr {
-              info: None,
-              kind: ExprKind::Boolean(result),
-            })?;
+            context.stack_push(ExprKind::Boolean(result).into())?;
 
             Ok(())
           }
-          _ => context.stack_push(Expr {
-            kind: ExprKind::Nil,
-            info: None,
-          }),
+          _ => context.stack_push(ExprKind::Nil.into()),
         }
         .map(|_| context)
       }
@@ -628,17 +613,11 @@ impl Intrinsic {
             let mut new_record = record.clone();
             new_record.remove(&symbol);
 
-            context.stack_push(Expr {
-              kind: ExprKind::Record(new_record),
-              info: None,
-            })?;
+            context.stack_push(ExprKind::Record(new_record).into())?;
 
             Ok(())
           }
-          _ => context.stack_push(Expr {
-            kind: ExprKind::Nil,
-            info: None,
-          }),
+          _ => context.stack_push(ExprKind::Nil.into()),
         }
         .map(|_| context)
       }
@@ -658,17 +637,11 @@ impl Intrinsic {
               .collect::<Vec<_>>();
 
             context.stack_push(record.clone())?;
-            context.stack_push(Expr {
-              info: None,
-              kind: ExprKind::List(result),
-            })?;
+            context.stack_push(ExprKind::List(result).into())?;
 
             Ok(())
           }
-          _ => context.stack_push(Expr {
-            kind: ExprKind::Nil,
-            info: None,
-          }),
+          _ => context.stack_push(ExprKind::Nil.into()),
         }
         .map(|_| context)
       }
@@ -681,17 +654,11 @@ impl Intrinsic {
             let result = r.values().cloned().collect::<Vec<_>>();
 
             context.stack_push(record.clone())?;
-            context.stack_push(Expr {
-              info: None,
-              kind: ExprKind::List(result),
-            })?;
+            context.stack_push(ExprKind::List(result).into())?;
 
             Ok(())
           }
-          _ => context.stack_push(Expr {
-            kind: ExprKind::Nil,
-            info: None,
-          }),
+          _ => context.stack_push(ExprKind::Nil.into()),
         }
         .map(|_| context)
       }
@@ -758,16 +725,10 @@ impl Intrinsic {
             (ExprKind::Record(x), "list") => {
               let mut list: Vec<Expr> = Vec::new();
               x.into_iter().for_each(|(key, value)| {
-                list.push(Expr {
-                  info: None,
-                  kind: ExprKind::List(vec![
-                    Expr {
-                      info: None,
-                      kind: ExprKind::Symbol(key),
-                    },
-                    value,
-                  ]),
-                });
+                list.push(
+                  ExprKind::List(vec![ExprKind::Symbol(key).into(), value])
+                    .into(),
+                );
               });
 
               ExprKind::List(list)

--- a/stack-core/src/intrinsic.rs
+++ b/stack-core/src/intrinsic.rs
@@ -89,6 +89,7 @@ intrinsics! {
   Values => "values",
 
   Cast => "cast",
+  TypeOf => "typeof",
   Lazy => "lazy",
 
   If => "if",
@@ -792,6 +793,15 @@ impl Intrinsic {
         };
 
         context.stack_push(kind.into())?;
+
+        Ok(context)
+      }
+      // MARK: TypeOf
+      Self::TypeOf => {
+        let expr = context.stack_pop(&expr)?;
+
+        context
+          .stack_push(ExprKind::String(expr.kind.type_of().into()).into())?;
 
         Ok(context)
       }

--- a/stack-core/src/intrinsic.rs
+++ b/stack-core/src/intrinsic.rs
@@ -388,8 +388,7 @@ impl Intrinsic {
         let index = context.stack_pop(&expr)?;
         let item = context.stack_pop(&expr)?;
 
-        // TODO: Can these eager clones be removed?
-        let kind = match (item.kind.clone(), index.kind.clone()) {
+        let kind = match (item.kind.clone(), index.kind) {
           (ExprKind::List(x), ExprKind::Integer(i)) if i >= 0 => x
             .get(i as usize)
             .map(|x| x.kind.clone())
@@ -414,8 +413,7 @@ impl Intrinsic {
         let index = context.stack_pop(&expr)?;
         let item = context.stack_pop(&expr)?;
 
-        // TODO: Can these eager clones be removed?
-        match (item.kind.clone(), index.kind.clone()) {
+        match (item.kind, index.kind) {
           (ExprKind::List(mut x), ExprKind::Integer(i)) if i >= 0 => {
             if (i as usize) < x.len() {
               let rest = x.split_off(i as usize);
@@ -459,8 +457,7 @@ impl Intrinsic {
         let rhs = context.stack_pop(&expr)?;
         let lhs = context.stack_pop(&expr)?;
 
-        // TODO: Can these eager clones be removed?
-        let kind = match (lhs.kind.clone(), rhs.kind.clone()) {
+        let kind = match (lhs.kind, rhs.kind) {
           (ExprKind::List(mut lhs), ExprKind::List(rhs)) => {
             lhs.extend(rhs);
             ExprKind::List(lhs)
@@ -547,17 +544,7 @@ impl Intrinsic {
 
         match record.kind {
           ExprKind::Record(ref record) => {
-            let symbol = match name.kind {
-              ExprKind::Symbol(s) => s,
-              ExprKind::String(s) => Symbol::from_ref(s.as_str()),
-              _ => {
-                return Err(RunError {
-                  context,
-                  expr,
-                  reason: RunErrorReason::UnknownCall,
-                })
-              }
-            };
+            let symbol: Symbol = name.kind.into();
 
             let mut new_record = record.clone();
             new_record.insert(symbol, value);
@@ -578,22 +565,12 @@ impl Intrinsic {
       }
       // MARK: Prop
       Self::Prop => {
-        let symbol = context.stack_pop(&expr)?;
+        let name = context.stack_pop(&expr)?;
         let record = context.stack_pop(&expr)?;
 
         match record.kind {
           ExprKind::Record(ref r) => {
-            let symbol = match symbol.kind {
-              ExprKind::Symbol(s) => s,
-              ExprKind::String(s) => Symbol::from_ref(s.as_str()),
-              _ => {
-                return Err(RunError {
-                  context,
-                  expr,
-                  reason: RunErrorReason::UnknownCall,
-                })
-              }
-            };
+            let symbol: Symbol = name.kind.into();
 
             let result = r.get(&symbol).unwrap_or_else(|| &Expr {
               info: None,
@@ -614,22 +591,12 @@ impl Intrinsic {
       }
       // MARK: Has
       Self::Has => {
-        let symbol = context.stack_pop(&expr)?;
+        let name = context.stack_pop(&expr)?;
         let record = context.stack_pop(&expr)?;
 
         match record.kind {
           ExprKind::Record(ref r) => {
-            let symbol = match symbol.kind {
-              ExprKind::Symbol(s) => s,
-              ExprKind::String(s) => Symbol::from_ref(s.as_str()),
-              _ => {
-                return Err(RunError {
-                  context,
-                  expr,
-                  reason: RunErrorReason::UnknownCall,
-                })
-              }
-            };
+            let symbol: Symbol = name.kind.into();
 
             let result = r.contains_key(&symbol);
 
@@ -655,17 +622,7 @@ impl Intrinsic {
 
         match record.kind {
           ExprKind::Record(ref record) => {
-            let symbol = match name.kind {
-              ExprKind::Symbol(s) => s,
-              ExprKind::String(s) => Symbol::from_ref(s.as_str()),
-              _ => {
-                return Err(RunError {
-                  context,
-                  expr,
-                  reason: RunErrorReason::UnknownCall,
-                })
-              }
-            };
+            let symbol: Symbol = name.kind.into();
 
             let mut new_record = record.clone();
             new_record.remove(&symbol);

--- a/stack-core/src/parser.rs
+++ b/stack-core/src/parser.rs
@@ -183,10 +183,7 @@ fn parse_record(
       TokenKind::RightCurly => break Ok((record, lexer.next().span)),
       _ => {
         if key.is_none() {
-          // TODO: Use `.into()` once we have the change that implements From<ExprKind> for Symbol
-          key = Some(Symbol::from_ref(
-            parse_expr(lexer)?.kind.to_compact_string().as_str(),
-          ));
+          key = Some(parse_expr(lexer)?.kind.into());
 
           continue;
         }

--- a/stack-core/src/parser.rs
+++ b/stack-core/src/parser.rs
@@ -1,7 +1,6 @@
+use compact_str::ToCompactString;
 use core::fmt;
 use std::collections::HashMap;
-
-use compact_str::ToCompactString;
 
 use crate::{
   expr::{Expr, ExprInfo, ExprKind, FnIdent},

--- a/stack-core/src/symbol.rs
+++ b/stack-core/src/symbol.rs
@@ -1,6 +1,6 @@
 use core::{borrow::Borrow, fmt, hash::Hash};
 
-use compact_str::CompactString;
+use compact_str::{CompactString, ToCompactString};
 use internment::Intern;
 
 use crate::expr::ExprKind;
@@ -41,6 +41,6 @@ impl fmt::Display for Symbol {
 
 impl From<ExprKind> for Symbol {
   fn from(value: ExprKind) -> Self {
-    Self::from_ref(value.to_string().as_str())
+    Self::from_ref(value.to_compact_string().as_str())
   }
 }

--- a/stack-core/src/symbol.rs
+++ b/stack-core/src/symbol.rs
@@ -3,6 +3,8 @@ use core::{borrow::Borrow, fmt, hash::Hash};
 use compact_str::CompactString;
 use internment::Intern;
 
+use crate::expr::ExprKind;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct Symbol(Intern<CompactString>);
@@ -34,5 +36,11 @@ impl Symbol {
 impl fmt::Display for Symbol {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     write!(f, "{}", self.as_str())
+  }
+}
+
+impl From<ExprKind> for Symbol {
+  fn from(value: ExprKind) -> Self {
+    Self::from_ref(value.to_string().as_str())
   }
 }

--- a/stack-core/tests/_runner.rs
+++ b/stack-core/tests/_runner.rs
@@ -5,8 +5,8 @@ use stack_core::prelude::*;
 use test_case::case;
 
 #[inline]
-const fn e(kind: ExprKind) -> Expr {
-  Expr { kind, info: None }
+fn e(kind: ExprKind) -> Expr {
+  kind.into()
 }
 
 // TODO: Add tests for missing intrinsics.

--- a/stack-std/src/fs.rs
+++ b/stack-std/src/fs.rs
@@ -7,16 +7,16 @@ pub fn module(sandbox: bool) -> Module {
   if !sandbox {
     module
       .add_func(Symbol::from_ref("cwd"), |_, mut context, _| {
-        context.stack_push(Expr {
-          kind: std::env::current_dir()
+        context.stack_push(
+          std::env::current_dir()
             .map(|x| {
               ExprKind::String(
                 x.to_string_lossy().into_owned().to_compact_string(),
               )
             })
-            .unwrap_or(ExprKind::Nil),
-          info: None,
-        })?;
+            .unwrap_or(ExprKind::Nil)
+            .into(),
+        )?;
 
         Ok(context)
       })
@@ -31,7 +31,7 @@ pub fn module(sandbox: bool) -> Module {
           _ => ExprKind::Nil,
         };
 
-        context.stack_push(Expr { kind, info: None })?;
+        context.stack_push(kind.into())?;
 
         Ok(context)
       });

--- a/stack-std/src/scope.rs
+++ b/stack-std/src/scope.rs
@@ -12,41 +12,23 @@ pub fn module() -> Module {
       match symbol.kind {
         ExprKind::Symbol(ref x) => {
           if Intrinsic::from_str(x.as_str()).is_ok() {
-            context.stack_push(Expr {
-              kind: ExprKind::String("intrinsic".into()),
-              info: None,
-            })
+            context.stack_push(ExprKind::String("intrinsic".into()).into())
           } else if engine
             .module(&Symbol::new(
               x.as_str().split(':').next().unwrap_or_default().into(),
             ))
             .is_some()
           {
-            context.stack_push(Expr {
-              kind: ExprKind::String("module".into()),
-              info: None,
-            })
+            context.stack_push(ExprKind::String("module".into()).into())
           } else if context.let_get(*x).is_some() {
-            context.stack_push(Expr {
-              kind: ExprKind::String("let".into()),
-              info: None,
-            })
+            context.stack_push(ExprKind::String("let".into()).into())
           } else if context.scope_item(*x).is_some() {
-            context.stack_push(Expr {
-              kind: ExprKind::String("scope".into()),
-              info: None,
-            })
+            context.stack_push(ExprKind::String("scope".into()).into())
           } else {
-            context.stack_push(Expr {
-              kind: ExprKind::Nil,
-              info: None,
-            })
+            context.stack_push(ExprKind::Nil.into())
           }
         }
-        _ => context.stack_push(Expr {
-          kind: ExprKind::Nil,
-          info: None,
-        }),
+        _ => context.stack_push(ExprKind::Nil.into()),
       }
       .map(|_| context)
     })
@@ -55,32 +37,21 @@ pub fn module() -> Module {
         .scope_items()
         .map(|(name, content)| {
           let list: Vec<Expr> = vec![
-            Expr {
-              kind: ExprKind::Symbol(*name),
-              info: None,
-            },
-            Expr {
-              kind: content
-                .borrow()
-                .val()
-                .map(|e| e.kind)
-                .unwrap_or(ExprKind::Nil),
-              info: None,
-            },
+            ExprKind::Symbol(*name).into(),
+            content
+              .borrow()
+              .val()
+              .map(|e| e.kind)
+              .unwrap_or(ExprKind::Nil)
+              .into(),
           ];
 
-          Expr {
-            kind: ExprKind::List(list),
-            info: None,
-          }
+          ExprKind::List(list).into()
         })
         .collect();
 
       context
-        .stack_push(Expr {
-          kind: ExprKind::List(items),
-          info: None,
-        })
+        .stack_push(ExprKind::List(items).into())
         .map(|_| context)
     });
 

--- a/stack-std/src/str.rs
+++ b/stack-std/src/str.rs
@@ -14,7 +14,7 @@ pub fn module() -> Module {
         _ => ExprKind::Nil,
       };
 
-      context.stack_push(Expr { kind, info: None })?;
+      context.stack_push(kind.into())?;
 
       Ok(context)
     })
@@ -26,7 +26,7 @@ pub fn module() -> Module {
         _ => ExprKind::Nil,
       };
 
-      context.stack_push(Expr { kind, info: None })?;
+      context.stack_push(kind.into())?;
 
       Ok(context)
     })
@@ -38,7 +38,7 @@ pub fn module() -> Module {
         _ => ExprKind::Nil,
       };
 
-      context.stack_push(Expr { kind, info: None })?;
+      context.stack_push(kind.into())?;
 
       Ok(context)
     })
@@ -53,7 +53,7 @@ pub fn module() -> Module {
         _ => ExprKind::Nil,
       };
 
-      context.stack_push(Expr { kind, info: None })?;
+      context.stack_push(kind.into())?;
 
       Ok(context)
     })
@@ -68,7 +68,7 @@ pub fn module() -> Module {
         _ => ExprKind::Nil,
       };
 
-      context.stack_push(Expr { kind, info: None })?;
+      context.stack_push(kind.into())?;
 
       Ok(context)
     })
@@ -79,16 +79,13 @@ pub fn module() -> Module {
       let kind = match (item.kind.clone(), patt.kind.clone()) {
         (ExprKind::String(ref x), ExprKind::String(ref y)) => ExprKind::List(
           x.split(y.as_str())
-            .map(|x| Expr {
-              kind: ExprKind::String(x.into()),
-              info: None,
-            })
+            .map(|x| ExprKind::String(x.into()).into())
             .collect(),
         ),
         _ => ExprKind::Nil,
       };
 
-      context.stack_push(Expr { kind, info: None })?;
+      context.stack_push(kind.into())?;
 
       Ok(context)
     })
@@ -100,16 +97,13 @@ pub fn module() -> Module {
         let kind = match item.kind {
           ExprKind::String(ref x) => ExprKind::List(
             x.split_whitespace()
-              .map(|x| Expr {
-                kind: ExprKind::String(x.into()),
-                info: None,
-              })
+              .map(|x| ExprKind::String(x.into()).into())
               .collect(),
           ),
           _ => ExprKind::Nil,
         };
 
-        context.stack_push(Expr { kind, info: None })?;
+        context.stack_push(kind.into())?;
 
         Ok(context)
       },
@@ -122,7 +116,7 @@ pub fn module() -> Module {
         _ => ExprKind::Nil,
       };
 
-      context.stack_push(Expr { kind, info: None })?;
+      context.stack_push(kind.into())?;
 
       Ok(context)
     })
@@ -134,7 +128,7 @@ pub fn module() -> Module {
         _ => ExprKind::Nil,
       };
 
-      context.stack_push(Expr { kind, info: None })?;
+      context.stack_push(kind.into())?;
 
       Ok(context)
     })
@@ -146,7 +140,7 @@ pub fn module() -> Module {
         _ => ExprKind::Nil,
       };
 
-      context.stack_push(Expr { kind, info: None })?;
+      context.stack_push(kind.into())?;
 
       Ok(context)
     })
@@ -160,7 +154,7 @@ pub fn module() -> Module {
         _ => ExprKind::Nil,
       };
 
-      context.stack_push(Expr { kind, info: None })?;
+      context.stack_push(kind.into())?;
 
       Ok(context)
     })
@@ -172,16 +166,13 @@ pub fn module() -> Module {
           x.as_bytes()
             .iter()
             .copied()
-            .map(|x| Expr {
-              kind: ExprKind::Integer(x as i64),
-              info: None,
-            })
+            .map(|x| ExprKind::Integer(x as i64).into())
             .collect(),
         ),
         _ => ExprKind::Nil,
       };
 
-      context.stack_push(Expr { kind, info: None })?;
+      context.stack_push(kind.into())?;
 
       Ok(context)
     })
@@ -207,7 +198,7 @@ pub fn module() -> Module {
         _ => ExprKind::Nil,
       };
 
-      context.stack_push(Expr { kind, info: None })?;
+      context.stack_push(kind.into())?;
 
       Ok(context)
     })
@@ -218,16 +209,13 @@ pub fn module() -> Module {
         ExprKind::String(ref x) => ExprKind::List(
           x.as_str()
             .graphemes(true)
-            .map(|x| Expr {
-              kind: ExprKind::String(x.into()),
-              info: None,
-            })
+            .map(|x| ExprKind::String(x.into()).into())
             .collect(),
         ),
         _ => ExprKind::Nil,
       };
 
-      context.stack_push(Expr { kind, info: None })?;
+      context.stack_push(kind.into())?;
 
       Ok(context)
     })
@@ -250,7 +238,7 @@ pub fn module() -> Module {
         _ => ExprKind::Nil,
       };
 
-      context.stack_push(Expr { kind, info: None })?;
+      context.stack_push(kind.into())?;
 
       Ok(context)
     })


### PR DESCRIPTION
Implements:
-  Conversions (`.into()`) that #31 has (without implementing expr tags).
- Basic `typeof` intrinsic (e.g. `'() typeof -> "list`)