### PR TITLE
Adds a function to get all of the intrinsics as strings

### DIFF
--- a/stack-core/src/intrinsic.rs
+++ b/stack-core/src/intrinsic.rs
@@ -28,6 +28,12 @@ macro_rules! intrinsics {
           $(Self::$ident => $s),*
         }
       }
+
+      /// Returns all of the [`Intrinsic`]s as a <code>&\[&[str]\]</code>.
+      // TODO: Is there a better name than this?
+      pub const fn all_as_slice() -> &'static [&'static str] {
+        &[$($s),*]
+      }
     }
 
     impl FromStr for Intrinsic {


### PR DESCRIPTION
This modifies the `macro_rules! intrinsics` to add an `all_as_slice` function that returns a static slice of static strings containing all of the intrinsics.