### PR TITLE
actually set the is_recur bool

### DIFF
--- a/stack-core/src/engine.rs
+++ b/stack-core/src/engine.rs
@@ -182,11 +182,12 @@ impl Engine {
             let fn_ident = item.kind.fn_symbol().unwrap();
             let fn_body = item.kind.fn_body().unwrap();
 
-            let mut context = context;
             let mut _call_result = CallResult::None;
+            let mut is_recur = false;
             loop {
               _call_result =
-                self.call_fn(&expr, fn_ident, fn_body, context, true);
+                self.call_fn(&expr, fn_ident, fn_body, context, is_recur);
+              is_recur = true;
 
               match _call_result {
                 CallResult::Recur(c) => context = c,

--- a/stack-core/src/scope.rs
+++ b/stack-core/src/scope.rs
@@ -409,4 +409,52 @@ mod tests {
       vec![&ExprKind::Integer(0),]
     );
   }
+
+  #[test]
+  fn setting_fn_to_var_preserves_scope() {
+    let source = Source::new(
+      "",
+      "'(fn 1 'a def 'f def f) 'test def (fn 0 'a def '(fn a)) test",
+    );
+    let mut lexer = Lexer::new(source);
+    let exprs = crate::parser::parse(&mut lexer).unwrap();
+
+    let engine = Engine::new();
+    let mut context = Context::new().with_stack_capacity(32);
+    context = engine.run(context, exprs).unwrap();
+
+    assert_eq!(context.scope_item(Symbol::new("a".into())), None);
+    assert_eq!(
+      context
+        .stack()
+        .iter()
+        .map(|expr| &expr.kind)
+        .collect::<Vec<_>>(),
+      vec![&ExprKind::Integer(0),]
+    );
+  }
+
+  #[test]
+  fn calling_function_with_same_var_preserves_scope() {
+    let source = Source::new(
+      "",
+      "'(fn 1 'a def call) 'test def (fn 0 'a def '(fn a)) test",
+    );
+    let mut lexer = Lexer::new(source);
+    let exprs = crate::parser::parse(&mut lexer).unwrap();
+
+    let engine = Engine::new();
+    let mut context = Context::new().with_stack_capacity(32);
+    context = engine.run(context, exprs).unwrap();
+
+    assert_eq!(context.scope_item(Symbol::new("a".into())), None);
+    assert_eq!(
+      context
+        .stack()
+        .iter()
+        .map(|expr| &expr.kind)
+        .collect::<Vec<_>>(),
+      vec![&ExprKind::Integer(0),]
+    );
+  }
 }


### PR DESCRIPTION
When calling functions from vars, the is_recur flag of `Engine::call_fn` was being hardcoded to `true` even though it should've been set accordingly.

This has been fixed and tests were added.