### PR TITLE
Basic regex methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,6 +832,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+
+[[package]]
 name = "rustix"
 version = "0.38.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,6 +991,7 @@ name = "stack-std"
 version = "0.1.0"
 dependencies = [
  "compact_str",
+ "regex",
  "stack-core",
  "unicode-segmentation",
 ]

--- a/stack-std/Cargo.toml
+++ b/stack-std/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 stack-core = { path = "../stack-core" }
 unicode-segmentation.workspace = true
 compact_str.workspace = true
+regex = "1.10.4"

--- a/stack-std/Cargo.toml
+++ b/stack-std/Cargo.toml
@@ -3,8 +3,12 @@ name = "stack-std"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = ["regex"]
+regex = ["dep:regex"]
+
 [dependencies]
 stack-core = { path = "../stack-core" }
 unicode-segmentation.workspace = true
 compact_str.workspace = true
-regex = "1.10.4"
+regex = { version = "1", optional = true }

--- a/stack-std/src/str.rs
+++ b/stack-std/src/str.rs
@@ -1,4 +1,5 @@
 use compact_str::{CompactString, ToCompactString};
+use regex::Regex;
 use stack_core::prelude::*;
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -236,6 +237,27 @@ pub fn module() -> Module {
           .map(ExprKind::String)
           .unwrap_or(ExprKind::Nil),
         _ => ExprKind::Nil,
+      };
+
+      context.stack_push(kind.into())?;
+
+      Ok(context)
+    })
+    .with_func(Symbol::from_ref("regex-test"), |_, mut context, expr| {
+      let pattern = context.stack_pop(&expr)?;
+      let string = context.stack_pop(&expr)?;
+
+      let kind = match (string.kind, pattern.kind) {
+        (ExprKind::String(ref string), ExprKind::String(ref pattern)) => {
+          let re = Regex::new(pattern);
+          match re {
+            Ok(re) => ExprKind::Boolean(re.captures(string).is_some()),
+            Err(err) => {
+              todo!()
+            }
+          }
+        }
+        (_, _) => ExprKind::Nil,
       };
 
       context.stack_push(kind.into())?;

--- a/stack-std/src/str.rs
+++ b/stack-std/src/str.rs
@@ -6,7 +6,7 @@ use unicode_segmentation::UnicodeSegmentation;
 // TODO: Add str:escape and str:unescape.
 
 pub fn module() -> Module {
-  Module::new(Symbol::from_ref("str"))
+  let mut module = Module::new(Symbol::from_ref("str"))
     .with_func(Symbol::from_ref("trim-start"), |_, mut context, expr| {
       let item = context.stack_pop(&expr)?;
 
@@ -242,64 +242,12 @@ pub fn module() -> Module {
       context.stack_push(kind.into())?;
 
       Ok(context)
-    })
-    .with_func(Symbol::from_ref("regex-test"), |_, mut context, expr| {
-      let pattern = context.stack_pop(&expr)?;
-      let string = context.stack_pop(&expr)?;
+    });
 
-      let kind = match (string.kind, pattern.kind) {
-        (ExprKind::String(ref string), ExprKind::String(ref pattern)) => {
-          let re = Regex::new(pattern);
-          match re {
-            Ok(re) => ExprKind::Boolean(re.captures(string).is_some()),
-            Err(err) => {
-              todo!()
-            }
-          }
-        }
-        (_, _) => ExprKind::Nil,
-      };
-
-      context.stack_push(kind.into())?;
-
-      Ok(context)
-    })
-    .with_func(Symbol::from_ref("regex-match"), |_, mut context, expr| {
-      let pattern = context.stack_pop(&expr)?;
-      let string = context.stack_pop(&expr)?;
-
-      let kind = match (string.kind, pattern.kind) {
-        (ExprKind::String(ref string), ExprKind::String(ref pattern)) => {
-          let re = Regex::new(pattern);
-          match re {
-            Ok(re) => re
-              .find(string)
-              .map(|m| {
-                ExprKind::String(
-                  string
-                    .chars()
-                    .skip(m.start())
-                    .take(m.end() - m.start())
-                    .collect::<String>()
-                    .into(),
-                )
-              })
-              .unwrap_or(ExprKind::Nil),
-            Err(err) => {
-              todo!()
-            }
-          }
-        }
-        (_, _) => ExprKind::Nil,
-      };
-
-      context.stack_push(kind.into())?;
-
-      Ok(context)
-    })
-    .with_func(
-      Symbol::from_ref("regex-match-all"),
-      |_, mut context, expr| {
+  #[cfg(feature = "regex")]
+  {
+    module = module
+      .with_func(Symbol::from_ref("regex-test"), |_, mut context, expr| {
         let pattern = context.stack_pop(&expr)?;
         let string = context.stack_pop(&expr)?;
 
@@ -307,21 +255,7 @@ pub fn module() -> Module {
           (ExprKind::String(ref string), ExprKind::String(ref pattern)) => {
             let re = Regex::new(pattern);
             match re {
-              Ok(re) => ExprKind::List(
-                re.find_iter(string)
-                  .map(|m| {
-                    ExprKind::String(
-                      string
-                        .chars()
-                        .skip(m.start())
-                        .take(m.end() - m.start())
-                        .collect::<String>()
-                        .into(),
-                    )
-                    .into()
-                  })
-                  .collect::<Vec<_>>(),
-              ),
+              Ok(re) => ExprKind::Boolean(re.captures(string).is_some()),
               Err(err) => {
                 todo!()
               }
@@ -333,6 +267,79 @@ pub fn module() -> Module {
         context.stack_push(kind.into())?;
 
         Ok(context)
-      },
-    )
+      })
+      .with_func(Symbol::from_ref("regex-match"), |_, mut context, expr| {
+        let pattern = context.stack_pop(&expr)?;
+        let string = context.stack_pop(&expr)?;
+
+        let kind = match (string.kind, pattern.kind) {
+          (ExprKind::String(ref string), ExprKind::String(ref pattern)) => {
+            let re = Regex::new(pattern);
+            match re {
+              Ok(re) => re
+                .find(string)
+                .map(|m| {
+                  ExprKind::String(
+                    string
+                      .chars()
+                      .skip(m.start())
+                      .take(m.end() - m.start())
+                      .collect::<String>()
+                      .into(),
+                  )
+                })
+                .unwrap_or(ExprKind::Nil),
+              Err(err) => {
+                todo!()
+              }
+            }
+          }
+          (_, _) => ExprKind::Nil,
+        };
+
+        context.stack_push(kind.into())?;
+
+        Ok(context)
+      })
+      .with_func(
+        Symbol::from_ref("regex-match-all"),
+        |_, mut context, expr| {
+          let pattern = context.stack_pop(&expr)?;
+          let string = context.stack_pop(&expr)?;
+
+          let kind = match (string.kind, pattern.kind) {
+            (ExprKind::String(ref string), ExprKind::String(ref pattern)) => {
+              let re = Regex::new(pattern);
+              match re {
+                Ok(re) => ExprKind::List(
+                  re.find_iter(string)
+                    .map(|m| {
+                      ExprKind::String(
+                        string
+                          .chars()
+                          .skip(m.start())
+                          .take(m.end() - m.start())
+                          .collect::<String>()
+                          .into(),
+                      )
+                      .into()
+                    })
+                    .collect::<Vec<_>>(),
+                ),
+                Err(err) => {
+                  todo!()
+                }
+              }
+            }
+            (_, _) => ExprKind::Nil,
+          };
+
+          context.stack_push(kind.into())?;
+
+          Ok(context)
+        },
+      )
+  }
+
+  module
 }


### PR DESCRIPTION
Added the following regex methods to the `str` module:
- `str:regex-test(string, pattern) -> bool`
- `str:regex-match(string, pattern) -> string`
- `str:regex-match-all(string, pattern) -> List(String)`