### PR TITLE
Remove ExprKind::Error

### DIFF
--- a/stack-core/src/engine.rs
+++ b/stack-core/src/engine.rs
@@ -8,7 +8,7 @@ use std::{
 use crate::{
   context::Context,
   expr::{
-    vec_fn_body, vec_fn_symbol, vec_is_function, Error, Expr, ExprKind, FnIdent,
+    vec_fn_body, vec_fn_symbol, vec_is_function, Expr, ExprKind, FnIdent,
   },
   intrinsic::Intrinsic,
   journal::JournalOp,

--- a/stack-core/src/engine.rs
+++ b/stack-core/src/engine.rs
@@ -135,11 +135,6 @@ impl Engine {
         context.stack_push(expr)?;
         Ok(context)
       }
-      ExprKind::Error(_) => Err(RunError {
-        reason: RunErrorReason::DoubleError,
-        context,
-        expr,
-      }),
       // TODO: This is temporary until a proper solution is created.
       ExprKind::Symbol(x) => {
         if let Some(journal) = context.journal_mut() {
@@ -172,11 +167,11 @@ impl Engine {
             }
             Ok(context)
           } else {
-            context.stack_push(
-              ExprKind::Error(Error::new("unknown function".into())).into(),
-            )?;
-
-            Ok(context)
+            Err(RunError {
+              context: context.clone(),
+              expr,
+              reason: RunErrorReason::UnknownCall,
+            })
           }
         } else if let Some(r#let) = context.let_get(x).cloned() {
           context.stack_push(r#let)?;

--- a/stack-core/src/expr.rs
+++ b/stack-core/src/expr.rs
@@ -49,7 +49,6 @@ impl fmt::Display for Expr {
 #[derive(Debug, Clone)]
 pub enum ExprKind {
   Nil,
-  Error(Error),
 
   Boolean(bool),
   Integer(i64),
@@ -121,7 +120,6 @@ impl ExprKind {
   pub fn type_of(&self) -> &str {
     match self {
       ExprKind::Nil => "nil",
-      ExprKind::Error(_) => "error",
 
       ExprKind::Boolean(_) => "boolean",
       ExprKind::Integer(_) => "integer",
@@ -143,7 +141,6 @@ impl PartialEq for ExprKind {
   fn eq(&self, other: &Self) -> bool {
     match (self, other) {
       (Self::Nil, Self::Nil) => true,
-      (Self::Error(lhs), Self::Error(rhs)) => lhs == rhs,
 
       (Self::Boolean(lhs), Self::Boolean(rhs)) => lhs == rhs,
       (Self::Integer(lhs), Self::Integer(rhs)) => lhs == rhs,
@@ -164,9 +161,6 @@ impl PartialOrd for ExprKind {
   fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
     match (self, other) {
       (Self::Nil, Self::Nil) => Some(Ordering::Equal),
-      (Self::Error(lhs), Self::Error(rhs)) => {
-        lhs.eq(rhs).then_some(Ordering::Equal)
-      }
 
       (Self::Boolean(lhs), Self::Boolean(rhs)) => {
         lhs.eq(rhs).then_some(Ordering::Equal)
@@ -270,7 +264,6 @@ impl fmt::Display for ExprKind {
     if f.alternate() {
       match self {
         Self::Nil => write!(f, "{}", "nil".green()),
-        Self::Error(x) => write!(f, "error({})", x.to_string().red()),
 
         Self::Boolean(x) => write!(f, "{}", x.to_string().green()),
         Self::Integer(x) => write!(f, "{}", x.to_string().blue()),
@@ -311,7 +304,6 @@ impl fmt::Display for ExprKind {
     } else {
       match self {
         Self::Nil => write!(f, "nil"),
-        Self::Error(x) => write!(f, "error({x})"),
 
         Self::Boolean(x) => write!(f, "{x}"),
         Self::Integer(x) => write!(f, "{x}"),

--- a/stack-debugger/src/lib.rs
+++ b/stack-debugger/src/lib.rs
@@ -36,10 +36,6 @@ pub fn paint_expr(expr: &Expr, layout_job: &mut LayoutJob) {
     ExprKind::Nil => {
       append_to_job(RichText::new("nil").color(green), layout_job)
     }
-    ExprKind::Error(x) => append_to_job(
-      RichText::new(format!("error({})", x)).color(red),
-      layout_job,
-    ),
     ExprKind::Boolean(x) => {
       append_to_job(RichText::new(x.to_string()).color(green), layout_job)
     }

--- a/stack-debugger/src/lib.rs
+++ b/stack-debugger/src/lib.rs
@@ -28,7 +28,6 @@ const YELLOW: &str = "#C19C00";
 
 pub fn paint_expr(expr: &Expr, layout_job: &mut LayoutJob) {
   let green = Color32::from_hex(GREEN).unwrap();
-  let red = Color32::from_hex(RED).unwrap();
   let blue = Color32::from_hex(BLUE).unwrap();
   let yellow = Color32::from_hex(YELLOW).unwrap();
 

--- a/stack-std/src/fs.rs
+++ b/stack-std/src/fs.rs
@@ -34,7 +34,7 @@ pub fn module(sandbox: bool) -> Module {
             ExprKind::String(ref x) => std::fs::read_to_string(x.as_str())
               .map(|x| x.to_compact_string())
               .map(ExprKind::String)
-              .unwrap_or_else(|e| ExprKind::Error(Error::new(e.to_string()))),
+              .unwrap_or(ExprKind::Nil),
             _ => ExprKind::Nil,
           };
 


### PR DESCRIPTION
Because errors weren't being handled, and because they weren't consistnet, I've decided to remove them for now, using `nil` as a replacement.