### PR TITLE
Swap args for if

### DIFF
--- a/stack-core/src/intrinsic.rs
+++ b/stack-core/src/intrinsic.rs
@@ -786,8 +786,8 @@ impl Intrinsic {
 
       // MARK: If
       Self::If => {
-        let cond = context.stack_pop(&expr)?;
         let body = context.stack_pop(&expr)?;
+        let cond = context.stack_pop(&expr)?;
 
         if cond.kind.is_truthy() {
           context = engine.run_expr(context, body)?;


### PR DESCRIPTION
As per: https://trello.com/c/iLjQgGeV/21-swap-block-and-condition-order-for-if, it would be nicer to have the condition for `if` be first, then the block.