### PR TITLE
Journal optimizations

### DIFF
--- a/stack-cli/src/main.rs
+++ b/stack-cli/src/main.rs
@@ -160,7 +160,7 @@ fn main() {
             Ok(context) => {
               print_stack(&context);
               if let Some(journal) = context.journal() {
-                eprintln!("{}", journal);
+                eprintln!("{:#}", journal);
               }
 
               context

--- a/stack-core/src/journal.rs
+++ b/stack-core/src/journal.rs
@@ -1,5 +1,4 @@
 use core::fmt;
-use std::mem;
 
 use crate::expr::{Expr, ExprKind};
 
@@ -109,7 +108,6 @@ impl fmt::Display for Journal {
       .take(self.size.unwrap_or(self.entries.len()))
     {
       let mut line = String::new();
-      let mut should_print = false;
       for op in entry.ops.iter() {
         if !line.is_empty() {
           line.push(' ');
@@ -121,47 +119,37 @@ impl fmt::Display for Journal {
               "{}",
               if f.alternate() { x.white() } else { x.new() }
             ));
-
-            should_print = true;
           }
           JournalOp::FnCall(x) => {
             line.push_str(&format!(
               "{}",
               if f.alternate() { x.yellow() } else { x.new() }
             ));
-
-            should_print = true;
           }
           JournalOp::Push(x) => {
             line.push_str(&format!(
               "{}",
               if f.alternate() { x.green() } else { x.new() }
             ));
-
-            should_print = true;
           }
           JournalOp::Pop(x) => {
             line.push_str(&format!(
               "{}",
               if f.alternate() { x.red() } else { x.new() }
             ));
-
-            should_print = true;
           }
           _ => {}
         }
       }
 
-      if should_print {
-        let bullet_symbol = match entry.scoped {
-          true => format!("{}*", "  ".repeat(entry.scope)),
-          false => {
-            format!("{}!", "  ".repeat(entry.scope))
-          }
-        };
-        write!(f, " {} ", bullet_symbol)?;
-        writeln!(f, "{}", line)?;
-      }
+      let bullet_symbol = match entry.scoped {
+        true => format!("{}*", "  ".repeat(entry.scope)),
+        false => {
+          format!("{}!", "  ".repeat(entry.scope))
+        }
+      };
+      write!(f, " {} ", bullet_symbol)?;
+      writeln!(f, "{}", line)?;
     }
 
     Ok(())
@@ -248,7 +236,6 @@ impl Journal {
     for entry in self
       .entries
       .iter()
-      .skip(1)
       .rev()
       .skip((self.entries.len() - 1) - from)
       .take(from - to)

--- a/stack-core/src/journal.rs
+++ b/stack-core/src/journal.rs
@@ -257,13 +257,15 @@ impl Journal {
     for (i, op) in self.ops.iter().enumerate().skip(start) {
       match op {
         JournalOp::Commit => {
-          entries.push(JournalEntry::new(
-            i,
-            ops,
-            scope,
-            *scoped.last().unwrap_or(&true),
-          ));
-          ops = Vec::new();
+          if !ops.is_empty() {
+            entries.push(JournalEntry::new(
+              i,
+              ops,
+              scope,
+              *scoped.last().unwrap_or(&true),
+            ));
+            ops = Vec::new();
+          }
         }
         JournalOp::FnStart(is_scoped) => {
           scope += 1;

--- a/stack-debugger/src/module.rs
+++ b/stack-debugger/src/module.rs
@@ -18,7 +18,7 @@ pub fn module(tx: mpsc::Sender<IOHookEvent>) -> Module {
           context
             .journal()
             .as_ref()
-            .map(|j| j.total_commits())
+            .map(|j| j.entries().len())
             .unwrap_or_default(),
           val.to_string(),
         ))
@@ -35,7 +35,7 @@ pub fn module(tx: mpsc::Sender<IOHookEvent>) -> Module {
             context
               .journal()
               .as_ref()
-              .map(|j| j.total_commits())
+              .map(|j| j.entries().len())
               .unwrap_or_default(),
           ))
           .unwrap();
@@ -51,7 +51,7 @@ pub fn module(tx: mpsc::Sender<IOHookEvent>) -> Module {
             context
               .journal()
               .as_ref()
-              .map(|j| j.total_commits())
+              .map(|j| j.entries().len())
               .unwrap_or_default(),
           ))
           .unwrap();


### PR DESCRIPTION
In this PR:
- Rewrote the journal to use entries as it's core datatype ([trello](https://trello.com/c/epnaMCSp/18-rewrite-journal-to-use-entries-as-the-core-datatype))
- Added methods to construct parts of the stack rather than scanning the entire set of ops each time ([trello](https://trello.com/c/90XdUnCH/24-cache-journal-construction-in-the-debugger))