### PR TITLE
Remove separate let scopes

### DIFF
--- a/docs/src/reference/builtins.md
+++ b/docs/src/reference/builtins.md
@@ -721,12 +721,17 @@ Pops `b.len()` items off of the stack, assigning each item the corresponding sym
 
 If list `b` was `(first second)`, then they would be popped from the stack in order, following this signature: `([first] [second] --)`.
 
+**Important Note:** Functions **cannot be used** as the block of a let (`a`). To use functions within lets, wrap them within the let block: `0 '((fn a)) '(a) let`. Lets create create their own scopes, so any `def` will be isolated to that `let`.
+
 **Examples:**
 ```clj
 10 2 '(a b -) '(a b) let
 ;; 8
 
-10 2 '(fn a b -) '(a b) let
+10 2
+'(
+  (fn a b -)
+) '(a b) let
 ;; 8
 
 10 2

--- a/stack-core/src/engine.rs
+++ b/stack-core/src/engine.rs
@@ -13,7 +13,6 @@ use crate::{
   intrinsic::Intrinsic,
   journal::JournalOp,
   module::Module,
-  scope::Scanner,
   symbol::Symbol,
 };
 

--- a/stack-core/src/engine.rs
+++ b/stack-core/src/engine.rs
@@ -473,7 +473,7 @@ mod tests {
 
   #[test]
   fn functions_work_in_lets() {
-    let source = Source::new("", "0 'a def 1 '(fn a 2 'a def a) '(a) let a");
+    let source = Source::new("", "0 'a def 1 '((fn a 2 'a def a)) '(a) let a");
     let mut lexer = Lexer::new(source);
     let exprs = crate::parser::parse(&mut lexer).unwrap();
 
@@ -496,37 +496,13 @@ mod tests {
   }
 
   #[test]
-  fn scopeless_functions_work_in_lets() {
-    let source = Source::new("", "0 'a def 1 '(fn! a 2 'a def a) '(a) let a");
-    let mut lexer = Lexer::new(source);
-    let exprs = crate::parser::parse(&mut lexer).unwrap();
-
-    let engine = Engine::new();
-    let mut context = Context::new().with_stack_capacity(32);
-    context = engine.run(context, exprs).unwrap();
-
-    assert_eq!(
-      context
-        .stack()
-        .iter()
-        .map(|expr| &expr.kind)
-        .collect::<Vec<_>>(),
-      vec![
-        &ExprKind::Integer(1),
-        &ExprKind::Integer(2),
-        &ExprKind::Integer(2),
-      ]
-    );
-  }
-
-  #[test]
   fn lets_dont_leak() {
     let source = Source::new(
       "",
       "0 'a def
       1 '(a) '(a) let
-      1 '(fn! a) '(a) let
-      1 '(fn a) '(a) let
+      1 '((fn! a)) '(a) let
+      1 '((fn a)) '(a) let
       a",
     );
     let mut lexer = Lexer::new(source);

--- a/stack-core/src/scope.rs
+++ b/stack-core/src/scope.rs
@@ -18,6 +18,7 @@ impl fmt::Debug for Scope {
 }
 
 impl Clone for Scope {
+  /// Clones the scope, using the same Arc's as self
   fn clone(&self) -> Self {
     let mut items = HashMap::new();
 
@@ -103,6 +104,7 @@ impl Scope {
     }
   }
 
+  /// Creates a new scope, linking the new symbols to that of self (such as for a function call)
   pub fn duplicate(&self) -> Self {
     let mut items = HashMap::new();
 

--- a/stack-std/src/scope.rs
+++ b/stack-std/src/scope.rs
@@ -16,8 +16,6 @@ pub fn module() -> Module {
           ExprKind::Symbol(ref x) => {
             if Intrinsic::from_str(x.as_str()).is_ok() {
               context.stack_push(ExprKind::String("intrinsic".into()).into())
-            } else if context.let_get(*x).is_some() {
-              context.stack_push(ExprKind::String("let".into()).into())
             } else if context.scope_item(*x).is_some() {
               context.stack_push(ExprKind::String("scope".into()).into())
             } else if engine.module(x).is_some() {


### PR DESCRIPTION
Let scopes originally used their own scoping system. Instead, I've merged their behavior to act like scoped functions. I have also added a note in the docs to not use functions directly as a let block, as it will lead to unexpected behavior.