### PR TITLE
Add a dedicated function type

### DIFF
--- a/docs/src/reference/builtins.md
+++ b/docs/src/reference/builtins.md
@@ -305,7 +305,7 @@ rot
 
 ### Length (`len`)
 
-**Signature:** `([a: list|string] -- int)`
+**Signature:** `([a: list|string|function] -- int)`
 
 **Equivalent Rust:** `a.len()`
 
@@ -320,7 +320,7 @@ rot
 
 ### Get at Index (`nth`)
 
-**Signature:** `([a: list] [b: int] -- a any)` or `([a: string] [b: int] -- a string)`
+**Signature:** `([a: list|function] [b: int] -- a any)` or `([a: string] [b: int] -- a string)`
 
 **Equivalent Rust:** `a[b]` or `a.get(b)`
 
@@ -356,7 +356,12 @@ Splits `a` at the separator `b` and returns both chunks.
 
 ### Concat (`concat`)
 
-**Signature:** `([a: list] [b: list] -- list)` or `([a: string] [b: string] -- string)`
+**Signatures:**
+- `([a: list] [b: list] -- list)`
+- `([a: string] [b: string] -- string)`
+- `([a: function] [b: function] -- function)`
+- `([a: function] [b: list] -- function)`
+- `([a: list] [b: function] -- list)`
 
 Concats `a` and `b` together (concats the two lists or two strings)
 
@@ -371,7 +376,7 @@ Concats `a` and `b` together (concats the two lists or two strings)
 
 ### Push (`push`)
 
-**Signature:** `([a] [b: list] -- list)`
+**Signature:** `([a] [b: list|function] -- b)` or `([a: string] [b: string] -- string)`
 
 **Equivalent Rust:** `b.push(a)`
 
@@ -386,7 +391,7 @@ Concats `a` and `b` together (concats the two lists or two strings)
 
 ### Pop (`pop`)
 
-**Signature:** `([a: list] -- any)` or `([a: string] -- any)`
+**Signature:** `([a: list|function] -- a any)` or `([a: string] -- string)`
 
 **Equivalent Rust:** `a.pop()`
 

--- a/stack-core/src/expr.rs
+++ b/stack-core/src/expr.rs
@@ -316,7 +316,9 @@ impl fmt::Display for ExprKind {
 
         Self::Function { scope, body } => {
           write!(f, "{}", "(".yellow())?;
-          write!(f, "{}", display_fn_scope(scope))?;
+
+          let sep = if body.is_empty() { "" } else { " " };
+          write!(f, "{}{sep}", display_fn_scope(scope).blue())?;
 
           core::iter::once("")
             .chain(core::iter::repeat(" "))

--- a/stack-core/src/expr.rs
+++ b/stack-core/src/expr.rs
@@ -46,6 +46,20 @@ impl fmt::Display for Expr {
   }
 }
 
+pub fn display_fn_scope(scope: &FnScope) -> String {
+  match scope {
+    FnScope::Scoped(..) => "fn",
+    FnScope::Scopeless => "fn!",
+  }
+  .into()
+}
+
+#[derive(Debug, Clone)]
+pub enum FnScope {
+  Scoped(Scope),
+  Scopeless,
+}
+
 #[derive(Debug, Clone)]
 pub enum ExprKind {
   Nil,
@@ -61,7 +75,7 @@ pub enum ExprKind {
   List(Vec<Expr>),
   Record(HashMap<Symbol, Expr>),
 
-  Fn(FnIdent),
+  Function { scope: FnScope, body: Vec<Expr> },
 }
 
 impl ExprKind {
@@ -73,34 +87,6 @@ impl ExprKind {
   #[inline]
   pub const fn is_truthy(&self) -> bool {
     matches!(self, Self::Boolean(true))
-  }
-
-  pub fn is_function(&self) -> bool {
-    match self {
-      Self::List(list) => vec_is_function(list),
-      _ => false,
-    }
-  }
-
-  pub fn fn_symbol(&self) -> Option<&FnIdent> {
-    match self {
-      Self::List(list) => vec_fn_symbol(list),
-      _ => None,
-    }
-  }
-
-  pub fn fn_symbol_mut(&mut self) -> Option<&mut FnIdent> {
-    match self {
-      Self::List(list) => vec_fn_symbol_mut(list),
-      _ => None,
-    }
-  }
-
-  pub fn fn_body(&self) -> Option<&[Expr]> {
-    match self {
-      Self::List(list) => vec_fn_body(list),
-      _ => None,
-    }
   }
 
   pub const fn unlazy(&self) -> &ExprKind {
@@ -132,7 +118,7 @@ impl ExprKind {
       ExprKind::List(_) => "list",
       ExprKind::Record(_) => "record",
 
-      ExprKind::Fn(_) => "function",
+      ExprKind::Function { .. } => "function",
     }
   }
 }
@@ -299,7 +285,17 @@ impl fmt::Display for ExprKind {
           write!(f, "}}")
         }
 
-        Self::Fn(x) => write!(f, "{}", x.to_string().yellow()),
+        Self::Function { scope, body } => {
+          write!(f, "{}", "(".yellow())?;
+          write!(f, "{}", display_fn_scope(scope))?;
+
+          core::iter::once("")
+            .chain(core::iter::repeat(" "))
+            .zip(body.iter())
+            .try_for_each(|(sep, x)| write!(f, "{sep}{x:#}"))?;
+
+          write!(f, "{}", ")".yellow())
+        }
       }
     } else {
       match self {
@@ -336,7 +332,17 @@ impl fmt::Display for ExprKind {
           write!(f, "}}")
         }
 
-        Self::Fn(x) => write!(f, "{x}"),
+        Self::Function { scope, body } => {
+          write!(f, "{}", "(")?;
+          write!(f, "{}", display_fn_scope(scope))?;
+
+          core::iter::once("")
+            .chain(core::iter::repeat(" "))
+            .zip(body.iter())
+            .try_for_each(|(sep, x)| write!(f, "{sep}{x:#}"))?;
+
+          write!(f, "{}", ")")
+        }
       }
     }
   }
@@ -382,22 +388,6 @@ impl fmt::Display for ErrorInner {
   }
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub struct FnIdent {
-  pub scoped: bool,
-  pub scope: Scope,
-}
-
-impl fmt::Display for FnIdent {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    if self.scoped {
-      write!(f, "fn")
-    } else {
-      write!(f, "fn!")
-    }
-  }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExprInfo {
   pub source: Source,
@@ -417,40 +407,4 @@ impl fmt::Display for ExprInfo {
         .unwrap_or_else(|| "?:?".into())
     )
   }
-}
-
-pub fn vec_is_function(list: &[Expr]) -> bool {
-  list
-    .first()
-    .map(|x| {
-      matches!(
-        x,
-        Expr {
-          kind: ExprKind::Fn(_),
-          ..
-        }
-      )
-    })
-    .unwrap_or(false)
-}
-
-pub fn vec_fn_symbol(list: &[Expr]) -> Option<&FnIdent> {
-  list.first().and_then(|x| match &x.kind {
-    ExprKind::Fn(scope) => Some(scope),
-    _ => None,
-  })
-}
-
-pub fn vec_fn_symbol_mut(list: &mut [Expr]) -> Option<&mut FnIdent> {
-  list.first_mut().and_then(|x| match &mut x.kind {
-    ExprKind::Fn(scope) => Some(scope),
-    _ => None,
-  })
-}
-
-pub fn vec_fn_body(list: &[Expr]) -> Option<&[Expr]> {
-  list.first().and_then(|x| match x.kind {
-    ExprKind::Fn(_) => Some(&list[1..]),
-    _ => None,
-  })
 }

--- a/stack-core/src/expr.rs
+++ b/stack-core/src/expr.rs
@@ -60,6 +60,18 @@ pub enum FnScope {
   Scopeless,
 }
 
+impl FnScope {
+  #[inline]
+  pub const fn is_scoped(&self) -> bool {
+    matches!(self, Self::Scoped(..))
+  }
+
+  #[inline]
+  pub const fn is_scopeless(&self) -> bool {
+    matches!(self, Self::Scopeless)
+  }
+}
+
 #[derive(Debug, Clone)]
 pub enum ExprKind {
   Nil,
@@ -92,6 +104,18 @@ impl ExprKind {
   #[inline]
   pub const fn is_function(&self) -> bool {
     matches!(self, Self::Function { .. })
+  }
+
+  #[inline]
+  pub const fn is_scoped(&self) -> Option<bool> {
+    match self {
+      Self::Function { scope, .. } => match scope {
+        FnScope::Scoped(..) => Some(true),
+        FnScope::Scopeless => Some(false),
+      },
+
+      _ => None,
+    }
   }
 
   pub const fn unlazy(&self) -> &ExprKind {

--- a/stack-core/src/expr.rs
+++ b/stack-core/src/expr.rs
@@ -365,12 +365,14 @@ impl fmt::Display for ExprKind {
 
         Self::Function { scope, body } => {
           write!(f, "(")?;
-          write!(f, "{}", display_fn_scope(scope))?;
+
+          let sep = if body.is_empty() { "" } else { " " };
+          write!(f, "{}{sep}", display_fn_scope(scope))?;
 
           core::iter::once("")
             .chain(core::iter::repeat(" "))
             .zip(body.iter())
-            .try_for_each(|(sep, x)| write!(f, "{sep}{x:#}"))?;
+            .try_for_each(|(sep, x)| write!(f, "{sep}{x}"))?;
 
           write!(f, ")")
         }

--- a/stack-core/src/expr.rs
+++ b/stack-core/src/expr.rs
@@ -89,6 +89,11 @@ impl ExprKind {
     matches!(self, Self::Boolean(true))
   }
 
+  #[inline]
+  pub const fn is_function(&self) -> bool {
+    matches!(self, Self::Function { .. })
+  }
+
   pub const fn unlazy(&self) -> &ExprKind {
     match self {
       ExprKind::Lazy(x) => x.kind.unlazy(),

--- a/stack-core/src/expr.rs
+++ b/stack-core/src/expr.rs
@@ -362,7 +362,7 @@ impl fmt::Display for ExprKind {
         }
 
         Self::Function { scope, body } => {
-          write!(f, "{}", "(")?;
+          write!(f, "(")?;
           write!(f, "{}", display_fn_scope(scope))?;
 
           core::iter::once("")
@@ -370,7 +370,7 @@ impl fmt::Display for ExprKind {
             .zip(body.iter())
             .try_for_each(|(sep, x)| write!(f, "{sep}{x:#}"))?;
 
-          write!(f, "{}", ")")
+          write!(f, ")")
         }
       }
     }

--- a/stack-core/src/intrinsic.rs
+++ b/stack-core/src/intrinsic.rs
@@ -812,6 +812,9 @@ impl Intrinsic {
             },
             (ExprKind::Function { body: x, .. }, "list")
             | (ExprKind::List(x), "list") => ExprKind::List(x),
+            (ExprKind::Function { scope, body }, "function") => {
+              ExprKind::Function { scope, body }
+            }
 
             _ => ExprKind::Nil,
           },

--- a/stack-core/src/journal.rs
+++ b/stack-core/src/journal.rs
@@ -37,6 +37,7 @@ pub enum JournalOp {
   Push(Expr),
   Pop(Expr),
 
+  /// bool determines if the function is scoped or not
   FnStart(bool),
   FnEnd,
 

--- a/stack-core/src/parser.rs
+++ b/stack-core/src/parser.rs
@@ -3,9 +3,8 @@ use core::fmt;
 use std::collections::HashMap;
 
 use crate::{
-  expr::{Expr, ExprInfo, ExprKind, FnScope},
+  expr::{Expr, ExprInfo, ExprKind},
   lexer::{Lexer, Span, Token, TokenKind},
-  scope::Scope,
   source::{Location, Source},
   symbol::Symbol,
 };

--- a/stack-core/src/parser.rs
+++ b/stack-core/src/parser.rs
@@ -3,8 +3,9 @@ use core::fmt;
 use std::collections::HashMap;
 
 use crate::{
-  expr::{Expr, ExprInfo, ExprKind, FnIdent},
+  expr::{Expr, ExprInfo, ExprKind, FnScope},
   lexer::{Lexer, Span, Token, TokenKind},
+  scope::Scope,
   source::{Location, Source},
   symbol::Symbol,
 };
@@ -137,14 +138,6 @@ fn parse_expr(lexer: &mut Lexer) -> Result<Expr, ParseError> {
           "nil" => ExprKind::Nil,
           "true" => ExprKind::Boolean(true),
           "false" => ExprKind::Boolean(false),
-          "fn" => ExprKind::Fn(FnIdent {
-            scoped: true,
-            scope: Default::default(),
-          }),
-          "fn!" => ExprKind::Fn(FnIdent {
-            scoped: false,
-            scope: Default::default(),
-          }),
           slice => ExprKind::Symbol(Symbol::from_ref(slice)),
         },
         info: Some(ExprInfo {

--- a/stack-core/src/scope.rs
+++ b/stack-core/src/scope.rs
@@ -57,10 +57,10 @@ impl Scope {
   }
 
   pub fn reserve(&mut self, name: Symbol) {
-    if self.items.get(&name).is_none() {
-      let val = Arc::new(RefCell::new(Chain::new(None)));
-      self.items.insert(name, val);
-    }
+    self
+      .items
+      .entry(name)
+      .or_insert_with(|| Arc::new(RefCell::new(Chain::new(None))));
   }
 
   pub fn set(
@@ -168,7 +168,7 @@ impl<'s> Scanner<'s> {
         Ok(expr)
       }
     } else {
-      return Err((expr, RunErrorReason::InvalidFunction));
+      Err((expr, RunErrorReason::InvalidFunction))
     }
   }
 }

--- a/stack-debugger/src/lib.rs
+++ b/stack-debugger/src/lib.rs
@@ -89,7 +89,10 @@ pub fn paint_expr(expr: &Expr, layout_job: &mut LayoutJob) {
     ExprKind::Function { scope, body } => {
       // append_to_job(RichText::new(x.to_string()).color(yellow), layout_job)
       append_to_job(RichText::new("("), layout_job);
-      append_to_job(RichText::new(display_fn_scope(scope)), layout_job);
+      append_to_job(
+        RichText::new(display_fn_scope(scope)).color(blue),
+        layout_job,
+      );
 
       for (sep, x) in core::iter::once("")
         .chain(core::iter::repeat(" "))

--- a/stack-debugger/src/lib.rs
+++ b/stack-debugger/src/lib.rs
@@ -3,7 +3,7 @@ pub mod module;
 use eframe::egui::{
   text::LayoutJob, Align, Color32, FontSelection, RichText, Style,
 };
-use stack_core::{journal::JournalOp, prelude::*};
+use stack_core::{expr::display_fn_scope, journal::JournalOp, prelude::*};
 
 pub enum IOHookEvent {
   Print(String),
@@ -86,8 +86,20 @@ pub fn paint_expr(expr: &Expr, layout_job: &mut LayoutJob) {
       append_to_job(RichText::new("}"), layout_job);
     }
 
-    ExprKind::Fn(x) => {
-      append_to_job(RichText::new(x.to_string()).color(yellow), layout_job)
+    ExprKind::Function { scope, body } => {
+      // append_to_job(RichText::new(x.to_string()).color(yellow), layout_job)
+      append_to_job(RichText::new("("), layout_job);
+      append_to_job(RichText::new(display_fn_scope(scope)), layout_job);
+
+      for (sep, x) in core::iter::once("")
+        .chain(core::iter::repeat(" "))
+        .zip(body.iter())
+      {
+        append_to_job(RichText::new(sep), layout_job);
+        paint_expr(x, layout_job);
+      }
+
+      append_to_job(RichText::new(")"), layout_job);
     }
   }
 }

--- a/stack-debugger/src/lib.rs
+++ b/stack-debugger/src/lib.rs
@@ -89,8 +89,10 @@ pub fn paint_expr(expr: &Expr, layout_job: &mut LayoutJob) {
     ExprKind::Function { scope, body } => {
       // append_to_job(RichText::new(x.to_string()).color(yellow), layout_job)
       append_to_job(RichText::new("("), layout_job);
+
+      let sep = if body.is_empty() { "" } else { " " };
       append_to_job(
-        RichText::new(display_fn_scope(scope)).color(blue),
+        RichText::new(format!("{}{sep}", display_fn_scope(scope))).color(blue),
         layout_job,
       );
 


### PR DESCRIPTION
In this PR:
- [x] Add a dedicated `ExprKind::Function` type
- [x] Update parser/lexer
- [x] Rewrite code that used old methods
- [x] Support functions in all list intrinsic
- [ ] Make the `fn` and `fn!` symbols invalid anywhere besides a list

**Considerations:**
- There is a way to cast a list into a scoped function, but not a scopeless function. For that, the user should do `'(fn!) '(2 2 +) concat`

**Questions?:**
- [x] Is it expected to have `'(fn 2 2 +) 1 split => (fn 2) (2 +)` or should it split into two separate functions, or just lists?