### PR TITLE
Fix debugger and journal bugs

### DIFF
--- a/stack-core/src/engine.rs
+++ b/stack-core/src/engine.rs
@@ -304,7 +304,7 @@ impl Engine {
         let scope = context.scope().clone();
         let journal = context.journal_mut().as_mut().unwrap();
         journal.commit();
-        journal.push_op(JournalOp::ScopedFnStart(scope));
+        journal.push_op(JournalOp::ScopedFnStart(scope.into()));
       } else {
         let journal = context.journal_mut().as_mut().unwrap();
         journal.commit();
@@ -314,9 +314,11 @@ impl Engine {
 
     match self.run(context, fn_body.to_vec()) {
       Ok(mut context) => {
-        if let Some(journal) = context.journal_mut() {
+        if context.journal().is_some() {
+          let scope = context.scope().clone();
+          let journal = context.journal_mut().as_mut().unwrap();
           journal.commit();
-          journal.push_op(JournalOp::FnEnd);
+          journal.push_op(JournalOp::FnEnd(scope.into()));
         }
 
         if context.stack().last().map(|e| &e.kind)

--- a/stack-core/src/engine.rs
+++ b/stack-core/src/engine.rs
@@ -135,7 +135,7 @@ impl Engine {
       }
 
       let mut args: Vec<Expr> = Vec::new();
-      for expr in body.into_iter() {
+      for expr in body {
         let stack_len = context.stack().len();
         match expr.kind {
           ExprKind::Underscore => args.push(context.stack_pop(expr)?),

--- a/stack-core/src/journal.rs
+++ b/stack-core/src/journal.rs
@@ -88,6 +88,7 @@ impl JournalOp {
   pub fn expr(&self) -> Option<&Expr> {
     match self {
       Self::Call(expr) => Some(expr),
+      Self::SCall(expr) => Some(expr),
       Self::FnCall(expr) => Some(expr),
       Self::Push(expr) => Some(expr),
       Self::Pop(expr) => Some(expr),

--- a/stack-core/src/journal.rs
+++ b/stack-core/src/journal.rs
@@ -61,6 +61,7 @@ impl fmt::Display for JournalOp {
     if f.alternate() {
       match self {
         Self::Call(call) => write!(f, "call({call})"),
+        Self::SCall(call) => write!(f, "{call}"),
         Self::FnCall(fn_call) => write!(f, "fn({fn_call})"),
         Self::Push(push) => write!(f, "push({push})"),
         Self::Pop(pop) => write!(f, "pop({pop})"),
@@ -69,6 +70,7 @@ impl fmt::Display for JournalOp {
     } else {
       match self {
         Self::Call(call) => write!(f, "{call}"),
+        Self::SCall(call) => write!(f, "{call}"),
         Self::FnCall(fn_call) => write!(f, "{fn_call}"),
         Self::Push(push) => write!(f, "{push}"),
         Self::Pop(pop) => write!(f, "{pop}"),

--- a/stack-core/src/journal.rs
+++ b/stack-core/src/journal.rs
@@ -1,21 +1,15 @@
 use core::fmt;
+use std::collections::HashMap;
 
 use crate::{
   expr::{Expr, ExprKind},
-  scope::{Scope, Val},
+  scope::Scope,
   symbol::Symbol,
 };
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct ScopeLevel {
-  pub scope_id: usize,
-  pub scoped: bool,
-}
-
-#[derive(Debug, Clone, PartialEq)]
 pub struct JournalEntry {
   pub ops: Vec<JournalOp>,
-  pub scope_id: usize,
   pub scope_level: usize,
   pub scoped: bool,
 }
@@ -36,15 +30,9 @@ impl fmt::Display for JournalEntry {
 }
 
 impl JournalEntry {
-  pub fn new(
-    ops: Vec<JournalOp>,
-    scope_id: usize,
-    scope_level: usize,
-    scoped: bool,
-  ) -> Self {
+  pub fn new(ops: Vec<JournalOp>, scope_level: usize, scoped: bool) -> Self {
     Self {
       ops,
-      scope_id,
       scope_level,
       scoped,
     }
@@ -58,11 +46,12 @@ pub enum JournalOp {
   Push(Expr),
   Pop(Expr),
 
-  ScopedFnStart(Scope),
+  ScopedFnStart(JournalScope),
   ScopelessFnStart,
-  FnEnd,
+  FnEnd(JournalScope),
 
-  ScopeSet(Symbol, Val),
+  ScopeDef(Symbol, Expr),
+  ScopeSet(Symbol, Expr, Expr),
 }
 
 impl fmt::Display for JournalOp {
@@ -104,14 +93,28 @@ impl JournalOp {
   }
 }
 
+pub type JournalScope = HashMap<Symbol, Expr>;
+
+impl From<Scope> for JournalScope {
+  fn from(value: Scope) -> Self {
+    let iter = value.items.into_iter().map(|(key, value)| {
+      (
+        key,
+        value.borrow().val().clone().unwrap_or(ExprKind::Nil.into()),
+      )
+    });
+
+    JournalScope::from_iter(iter)
+  }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 // TODO: implement this as a ring buffer with max_commits so we never go over
 pub struct Journal {
   ops: Vec<JournalOp>,
 
   entries: Vec<JournalEntry>,
-  scopes: Vec<Scope>,
-  scope_levels: Vec<ScopeLevel>,
+  scope_levels: Vec<bool>,
 
   size: Option<usize>,
 }
@@ -192,11 +195,7 @@ impl Journal {
       ops: Vec::new(),
 
       entries: Vec::new(),
-      scopes: vec![Scope::new()],
-      scope_levels: vec![ScopeLevel {
-        scope_id: 0,
-        scoped: false,
-      }],
+      scope_levels: vec![false],
 
       size: None,
     }
@@ -213,61 +212,29 @@ impl Journal {
   }
 
   pub fn push_op(&mut self, op: JournalOp) {
-    match op {
-      JournalOp::ScopedFnStart(s) => {
-        let mut scope: Scope = Scope::new();
-        for (key, value) in s.items.into_iter() {
-          scope.items.insert(key, value);
-        }
-
-        self.scopes.push(scope);
-        self.scope_levels.push(ScopeLevel {
-          scope_id: self.scopes.len().saturating_sub(1),
-          scoped: true,
-        });
+    match &op {
+      JournalOp::ScopedFnStart(..) => {
+        self.scope_levels.push(true);
       }
       JournalOp::ScopelessFnStart => {
-        self.scope_levels.push(ScopeLevel {
-          scope_id: self.scopes.len().saturating_sub(1),
-          scoped: false,
-        });
+        self.scope_levels.push(false);
       }
-      JournalOp::FnEnd => {
+      JournalOp::FnEnd(..) => {
         self.scope_levels.pop();
       }
-      JournalOp::ScopeSet(key, value) => {
-        let mut scope = self.scopes.last().cloned().unwrap_or_default();
-        scope.items.insert(key, value);
-        if let Some(ref mut scope_level) = self.scope_levels.last_mut() {
-          scope_level.scope_id = self.scopes.len();
-        }
 
-        self.scopes.push(scope);
-      }
-
-      op => self.ops.push(op.clone()),
+      _ => {}
     }
-  }
 
-  pub fn scope(&self, id: usize) -> Option<&Scope> {
-    self.scopes.get(id)
+    self.ops.push(op)
   }
 
   pub fn commit(&mut self) {
     if !self.ops.is_empty() {
       self.entries.push(JournalEntry {
         ops: self.ops.drain(..).collect(),
-        scope_id: self
-          .scope_levels
-          .last()
-          .map(|level| level.scope_id)
-          .unwrap_or_default(),
         scope_level: self.scope_levels.len(),
-        scoped: self
-          .scope_levels
-          .last()
-          .map(|level| level.scoped)
-          .unwrap_or_default(),
+        scoped: self.scope_levels.last().copied().unwrap_or_default(),
       });
     }
   }
@@ -284,9 +251,32 @@ impl Journal {
     self.len() == 0
   }
 
-  fn construct_entry(&self, entry: &JournalEntry, stack: &mut Vec<Expr>) {
+  fn construct_entry(
+    &self,
+    entry: &JournalEntry,
+    stack: &mut Vec<Expr>,
+    scopes: &mut Vec<JournalScope>,
+  ) {
     for op in entry.ops.iter() {
       match op {
+        JournalOp::ScopedFnStart(scope) => {
+          scopes.push(scope.clone());
+        }
+        JournalOp::FnEnd(..) => {
+          scopes.pop();
+        }
+        JournalOp::ScopeDef(key, value) => {
+          let scope = scopes.last_mut();
+          if let Some(scope) = scope {
+            scope.insert(*key, value.clone());
+          }
+        }
+        JournalOp::ScopeSet(key, _, value) => {
+          let scope = scopes.last_mut();
+          if let Some(scope) = scope {
+            scope.insert(*key, value.clone());
+          }
+        }
         JournalOp::Push(expr) => stack.push(expr.clone()),
         JournalOp::Pop(_) => {
           stack.pop();
@@ -312,9 +302,32 @@ impl Journal {
     }
   }
 
-  fn unconstruct_entry(&self, entry: &JournalEntry, stack: &mut Vec<Expr>) {
+  fn unconstruct_entry(
+    &self,
+    entry: &JournalEntry,
+    stack: &mut Vec<Expr>,
+    scopes: &mut Vec<JournalScope>,
+  ) {
     for op in entry.ops.iter().rev() {
       match op {
+        JournalOp::ScopedFnStart(..) => {
+          scopes.pop();
+        }
+        JournalOp::FnEnd(scope) => {
+          scopes.push(scope.clone());
+        }
+        JournalOp::ScopeDef(key, ..) => {
+          let scope = scopes.last_mut();
+          if let Some(scope) = scope {
+            scope.remove(key);
+          }
+        }
+        JournalOp::ScopeSet(key, old_value, _) => {
+          let scope = scopes.last_mut();
+          if let Some(scope) = scope {
+            scope.insert(*key, old_value.clone());
+          }
+        }
         JournalOp::Push(_) => {
           stack.pop();
         }
@@ -342,13 +355,14 @@ impl Journal {
   pub fn construct_to_from(
     &self,
     stack: &mut Vec<Expr>,
+    scopes: &mut Vec<JournalScope>,
     to: usize,
     from: usize,
   ) {
     let skip = (self.entries.len() - 1) - from;
     let take = from - to;
     for entry in self.entries.iter().rev().skip(skip).take(take) {
-      self.unconstruct_entry(entry, stack);
+      self.unconstruct_entry(entry, stack, scopes);
     }
   }
 
@@ -356,6 +370,7 @@ impl Journal {
   pub fn construct_from_to(
     &self,
     stack: &mut Vec<Expr>,
+    scopes: &mut Vec<JournalScope>,
     from: usize,
     to: usize,
   ) {
@@ -363,22 +378,27 @@ impl Journal {
     let take = to - from;
 
     for entry in self.entries.iter().skip(skip).take(take) {
-      self.construct_entry(entry, stack);
+      self.construct_entry(entry, stack, scopes);
     }
   }
 
-  pub fn construct_at_zero(&self, stack: &mut Vec<Expr>) {
+  pub fn construct_at_zero(
+    &self,
+    stack: &mut Vec<Expr>,
+    scopes: &mut Vec<JournalScope>,
+  ) {
     if let Some(entry) = self.entries.first() {
-      self.construct_entry(entry, stack);
+      self.construct_entry(entry, stack, scopes);
     }
   }
 
-  pub fn construct_to(&self, index: usize) -> Vec<Expr> {
+  pub fn construct_to(&self, index: usize) -> (Vec<Expr>, Vec<JournalScope>) {
     let mut stack = Vec::new();
-    self.construct_at_zero(&mut stack);
-    self.construct_from_to(&mut stack, 0, index);
+    let mut scopes = vec![JournalScope::new()];
+    self.construct_at_zero(&mut stack, &mut scopes);
+    self.construct_from_to(&mut stack, &mut scopes, 0, index);
 
-    stack
+    (stack, scopes)
   }
 
   // pub fn trim_to(mut self, index: usize) -> Self {

--- a/stack-core/src/journal.rs
+++ b/stack-core/src/journal.rs
@@ -153,6 +153,12 @@ impl fmt::Display for Journal {
               if f.alternate() { x.white() } else { x.new() }
             ));
           }
+          JournalOp::SCall(x) => {
+            line.push_str(&format!(
+              "{}",
+              if f.alternate() { x.yellow() } else { x.new() }
+            ));
+          }
           JournalOp::FnCall(x) => {
             line.push_str(&format!(
               "{}",

--- a/stack-debugger/src/lib.rs
+++ b/stack-debugger/src/lib.rs
@@ -300,8 +300,12 @@ pub fn string_with_quotes(expr: &Expr) -> String {
       string
     }
 
-    ExprKind::SExpr { body, .. } => {
+    ExprKind::SExpr { call, body } => {
       let mut string = String::from("(");
+
+      let sep = if body.is_empty() { "" } else { " " };
+      string.push_str(format!("{}{sep}", call.as_str()).as_str());
+
       core::iter::once("")
         .chain(core::iter::repeat(" "))
         .zip(body.iter())

--- a/stack-debugger/src/lib.rs
+++ b/stack-debugger/src/lib.rs
@@ -5,7 +5,9 @@ use eframe::egui::{
 };
 use itertools::Itertools;
 use stack_core::{
-  expr::display_fn_scope, journal::JournalOp, prelude::*, scope::Scope,
+  expr::display_fn_scope,
+  journal::{Journal, JournalOp, JournalScope},
+  prelude::*,
 };
 
 pub enum IOHookEvent {
@@ -138,42 +140,6 @@ pub fn paint_expr(expr: &Expr, layout_job: &mut LayoutJob) {
   }
 }
 
-pub fn string_with_quotes(expr: &Expr) -> String {
-  match &expr.kind {
-    ExprKind::String(x) => format!("\"{x}\""),
-
-    ExprKind::Lazy(x) => string_with_quotes(x),
-
-    ExprKind::List(x) => {
-      let mut string = String::from("(");
-      core::iter::once("")
-        .chain(core::iter::repeat(" "))
-        .zip(x.iter())
-        .for_each(|(sep, x)| {
-          string.push_str(&format!("{sep}{}", string_with_quotes(x)))
-        });
-      string.push(')');
-
-      string
-    }
-
-    ExprKind::Record(x) => {
-      let mut string = String::from("{");
-      core::iter::once("")
-        .chain(core::iter::repeat(" "))
-        .zip(x.iter())
-        .for_each(|(sep, (key, value))| {
-          string.push_str(&format!("{sep}{key}: {}", string_with_quotes(value)))
-        });
-      string.push('}');
-
-      string
-    }
-
-    kind => kind.to_string(),
-  }
-}
-
 pub fn paint_op(op: &JournalOp, layout_job: &mut LayoutJob) {
   let green = Color32::from_hex(GREEN).unwrap();
   let red = Color32::from_hex(RED).unwrap();
@@ -220,23 +186,118 @@ pub fn paint_op(op: &JournalOp, layout_job: &mut LayoutJob) {
       )
     }
     JournalOp::ScopedFnStart(_) => {
-      append_to_job(RichText::new("scope: fn(start)"), layout_job);
+      append_to_job(RichText::new("fn(start)"), layout_job);
     }
     JournalOp::ScopelessFnStart => {
-      append_to_job(RichText::new("scope: fn!(start)"), layout_job);
+      append_to_job(RichText::new("fn!(start)"), layout_job);
     }
-    JournalOp::FnEnd => {
-      append_to_job(RichText::new("scope: fn(end)"), layout_job);
+    JournalOp::FnEnd(..) => {
+      append_to_job(RichText::new("fn(end)"), layout_job);
     }
     _ => {}
   }
 }
 
-pub fn paint_scope(scope: &Scope, layout_job: &mut LayoutJob) {
-  for (key, value) in scope.items.iter().sorted_by_key(|(a, _)| a.as_str()) {
-    let value = value.borrow().val().unwrap_or(ExprKind::Nil.into());
+pub fn paint_scope(scope: &JournalScope, layout_job: &mut LayoutJob) {
+  for (key, value) in scope.iter().sorted_by_key(|(a, _)| a.as_str()) {
     append_to_job(RichText::new(format!("{}: ", key)), layout_job);
-    paint_expr(&value, layout_job);
+    paint_expr(value, layout_job);
     append_to_job(RichText::new("\n"), layout_job);
+  }
+}
+
+pub fn paint_journal(journal: &Journal, layout_job: &mut LayoutJob) {
+  let green = Color32::from_hex(GREEN).unwrap();
+  let red = Color32::from_hex(RED).unwrap();
+  let yellow = Color32::from_hex(YELLOW).unwrap();
+
+  if !journal.entries().is_empty() {
+    append_to_job(
+      RichText::new("Stack History (most recent first):\n")
+        .color(Color32::WHITE),
+      layout_job,
+    );
+  }
+
+  for entry in journal.entries().iter().rev().take(journal.entries().len()) {
+    let bullet_symbol = match entry.scoped {
+      true => format!("{}*", "  ".repeat(entry.scope_level)),
+      false => {
+        format!("{}!", "  ".repeat(entry.scope_level))
+      }
+    };
+
+    append_to_job(
+      RichText::new(format!(" {} ", bullet_symbol)).monospace(),
+      layout_job,
+    );
+
+    for (i, op) in entry.ops.iter().enumerate() {
+      if i != 0 {
+        append_to_job(RichText::new(" ").monospace(), layout_job);
+      }
+
+      match op {
+        JournalOp::Call(x) => {
+          append_to_job(RichText::new(x.to_string()).monospace(), layout_job);
+        }
+        JournalOp::FnCall(x) => {
+          append_to_job(
+            RichText::new(x.to_string()).color(yellow).monospace(),
+            layout_job,
+          );
+        }
+        JournalOp::Push(x) => {
+          append_to_job(
+            RichText::new(x.to_string()).color(green).monospace(),
+            layout_job,
+          );
+        }
+        JournalOp::Pop(x) => {
+          append_to_job(
+            RichText::new(x.to_string()).color(red).monospace(),
+            layout_job,
+          );
+        }
+        _ => {}
+      }
+    }
+    append_to_job(RichText::new("\n").monospace(), layout_job);
+  }
+}
+
+pub fn string_with_quotes(expr: &Expr) -> String {
+  match &expr.kind {
+    ExprKind::String(x) => format!("\"{x}\""),
+
+    ExprKind::Lazy(x) => string_with_quotes(x),
+
+    ExprKind::List(x) => {
+      let mut string = String::from("(");
+      core::iter::once("")
+        .chain(core::iter::repeat(" "))
+        .zip(x.iter())
+        .for_each(|(sep, x)| {
+          string.push_str(&format!("{sep}{}", string_with_quotes(x)))
+        });
+      string.push(')');
+
+      string
+    }
+
+    ExprKind::Record(x) => {
+      let mut string = String::from("{");
+      core::iter::once("")
+        .chain(core::iter::repeat(" "))
+        .zip(x.iter())
+        .for_each(|(sep, (key, value))| {
+          string.push_str(&format!("{sep}{key}: {}", string_with_quotes(value)))
+        });
+      string.push('}');
+
+      string
+    }
+
+    kind => kind.to_string(),
   }
 }

--- a/stack-debugger/src/lib.rs
+++ b/stack-debugger/src/lib.rs
@@ -250,6 +250,12 @@ pub fn paint_journal(journal: &Journal, layout_job: &mut LayoutJob) {
         JournalOp::Call(x) => {
           append_to_job(RichText::new(x.to_string()).monospace(), layout_job);
         }
+        JournalOp::SCall(x) => {
+          append_to_job(
+            RichText::new(x.to_string()).color(yellow).monospace(),
+            layout_job,
+          );
+        }
         JournalOp::FnCall(x) => {
           append_to_job(
             RichText::new(x.to_string()).color(yellow).monospace(),
@@ -286,6 +292,19 @@ pub fn string_with_quotes(expr: &Expr) -> String {
       core::iter::once("")
         .chain(core::iter::repeat(" "))
         .zip(x.iter())
+        .for_each(|(sep, x)| {
+          string.push_str(&format!("{sep}{}", string_with_quotes(x)))
+        });
+      string.push(')');
+
+      string
+    }
+
+    ExprKind::SExpr { body, .. } => {
+      let mut string = String::from("(");
+      core::iter::once("")
+        .chain(core::iter::repeat(" "))
+        .zip(body.iter())
         .for_each(|(sep, x)| {
           string.push_str(&format!("{sep}{}", string_with_quotes(x)))
         });

--- a/stack-debugger/src/lib.rs
+++ b/stack-debugger/src/lib.rs
@@ -156,6 +156,15 @@ pub fn paint_op(op: &JournalOp, layout_job: &mut LayoutJob) {
         layout_job,
       )
     }
+    JournalOp::SCall(expr) => {
+      // append_to_job(RichText::new("call(").color(yellow), layout_job);
+      // paint_expr(expr, layout_job);
+      // append_to_job(RichText::new(")").color(yellow), layout_job)
+      append_to_job(
+        RichText::new(format!("{}", string_with_quotes(expr))).color(yellow),
+        layout_job,
+      )
+    }
     JournalOp::FnCall(expr) => {
       // append_to_job(RichText::new("fn(").color(yellow), layout_job);
       // paint_expr(expr, layout_job);

--- a/stack-debugger/src/lib.rs
+++ b/stack-debugger/src/lib.rs
@@ -117,7 +117,7 @@ pub fn paint_expr(expr: &Expr, layout_job: &mut LayoutJob) {
     }
 
     ExprKind::SExpr { call, body } => {
-      append_to_job(RichText::new("(").color(yellow), layout_job);
+      append_to_job(RichText::new("("), layout_job);
 
       let sep = if body.is_empty() { "" } else { " " };
       append_to_job(
@@ -146,62 +146,34 @@ pub fn paint_op(op: &JournalOp, layout_job: &mut LayoutJob) {
   let yellow = Color32::from_hex(YELLOW).unwrap();
 
   match op {
-    JournalOp::Call(expr) => {
-      // append_to_job(RichText::new("call(").color(yellow), layout_job);
-      // paint_expr(expr, layout_job);
-      // append_to_job(RichText::new(")").color(yellow), layout_job)
-      append_to_job(
-        RichText::new(format!("scope({})", string_with_quotes(expr)))
-          .color(yellow),
-        layout_job,
-      )
-    }
-    JournalOp::SCall(expr) => {
-      // append_to_job(RichText::new("call(").color(yellow), layout_job);
-      // paint_expr(expr, layout_job);
-      // append_to_job(RichText::new(")").color(yellow), layout_job)
-      append_to_job(
-        RichText::new(format!("{}", string_with_quotes(expr))).color(yellow),
-        layout_job,
-      )
-    }
-    JournalOp::FnCall(expr) => {
-      // append_to_job(RichText::new("fn(").color(yellow), layout_job);
-      // paint_expr(expr, layout_job);
-      // append_to_job(RichText::new(")").color(yellow), layout_job)
-      append_to_job(
-        RichText::new(format!("fn({})", string_with_quotes(expr)))
-          .color(yellow),
-        layout_job,
-      )
-    }
-    JournalOp::Push(expr) => {
-      // append_to_job(RichText::new("push(").color(green), layout_job);
-      // paint_expr(expr, layout_job);
-      // append_to_job(RichText::new(")").color(green), layout_job)
-      append_to_job(
-        RichText::new(format!("push({})", string_with_quotes(expr)))
-          .color(green),
-        layout_job,
-      )
-    }
-    JournalOp::Pop(expr) => {
-      // append_to_job(RichText::new("pop(").color(red), layout_job);
-      // paint_expr(expr, layout_job);
-      // append_to_job(RichText::new(")").color(red), layout_job)
-      append_to_job(
-        RichText::new(format!("pop({})", string_with_quotes(expr))).color(red),
-        layout_job,
-      )
-    }
+    JournalOp::Call(expr) => append_to_job(
+      RichText::new(format!("get({})", string_with_quotes(expr))).color(yellow),
+      layout_job,
+    ),
+    JournalOp::SCall(expr) => append_to_job(
+      RichText::new(format!("{}", string_with_quotes(expr))).color(yellow),
+      layout_job,
+    ),
+    JournalOp::FnCall(expr) => append_to_job(
+      RichText::new(format!("{}", string_with_quotes(expr))).color(yellow),
+      layout_job,
+    ),
+    JournalOp::Push(expr) => append_to_job(
+      RichText::new(format!("push({})", string_with_quotes(expr))).color(green),
+      layout_job,
+    ),
+    JournalOp::Pop(expr) => append_to_job(
+      RichText::new(format!("pop({})", string_with_quotes(expr))).color(red),
+      layout_job,
+    ),
     JournalOp::ScopedFnStart(_) => {
-      append_to_job(RichText::new("fn(start)"), layout_job);
+      append_to_job(RichText::new("fn start"), layout_job);
     }
     JournalOp::ScopelessFnStart => {
-      append_to_job(RichText::new("fn!(start)"), layout_job);
+      append_to_job(RichText::new("fn! start"), layout_job);
     }
     JournalOp::FnEnd(..) => {
-      append_to_job(RichText::new("fn(end)"), layout_job);
+      append_to_job(RichText::new("fn end"), layout_job);
     }
     _ => {}
   }


### PR DESCRIPTION
- [x] [Index out of bounds on swap ops](https://trello.com/c/VyeGxbDU/30-journal-index-out-of-bounds-related-to-swap-operations)
  - Ensure that we set last_index after we reload
- [x] [Memory leak on slider change or reload](https://trello.com/c/9S6eIF6k/31-memory-leak-when-using-the-slider-or-reloading)
  - Removed the journal output, fixed for now, lol
- [x] [Journal only reports the latest value for scopes](https://trello.com/c/P9qiCC2P/32-journal-reports-newest-value-for-scopes)
  - Implemented op-based scope mutations so they can be stored within the ops (saving on _some_ memory)