### PR TITLE
add expr info to function (scope) ops

### DIFF
--- a/stack-core/src/engine.rs
+++ b/stack-core/src/engine.rs
@@ -312,11 +312,12 @@ impl Engine {
         let scope = context.scope().clone();
         let journal = context.journal_mut().as_mut().unwrap();
         journal.commit();
-        journal.push_op(JournalOp::ScopedFnStart(scope.into()));
+        journal
+          .push_op(JournalOp::ScopedFnStart(expr.info.clone(), scope.into()));
       } else {
         let journal = context.journal_mut().as_mut().unwrap();
         journal.commit();
-        journal.push_op(JournalOp::ScopelessFnStart);
+        journal.push_op(JournalOp::ScopelessFnStart(expr.info.clone()));
       }
     }
 
@@ -326,7 +327,7 @@ impl Engine {
           let scope = context.scope().clone();
           let journal = context.journal_mut().as_mut().unwrap();
           journal.commit();
-          journal.push_op(JournalOp::FnEnd(scope.into()));
+          journal.push_op(JournalOp::FnEnd(expr.info.clone(), scope.into()));
         }
 
         if context.stack().last().map(|e| &e.kind)

--- a/stack-core/src/intrinsic.rs
+++ b/stack-core/src/intrinsic.rs
@@ -847,7 +847,7 @@ impl Intrinsic {
 
             if let Some(journal) = context.journal_mut() {
               journal.commit();
-              journal.push_op(JournalOp::ScopelessFnStart);
+              journal.push_op(JournalOp::ScopelessFnStart(expr.info.clone()));
             }
 
             context.push_scope(scope);
@@ -857,7 +857,8 @@ impl Intrinsic {
               let scope = context.scope().clone();
               let journal = context.journal_mut().as_mut().unwrap();
               journal.commit();
-              journal.push_op(JournalOp::FnEnd(scope.into()));
+              journal
+                .push_op(JournalOp::FnEnd(expr.info.clone(), scope.into()));
             }
 
             context.pop_scope();
@@ -995,7 +996,7 @@ impl Intrinsic {
         // Imports should trigger a new commit
         if let Some(journal) = context.journal_mut() {
           journal.commit();
-          journal.push_op(JournalOp::ScopelessFnStart);
+          journal.push_op(JournalOp::ScopelessFnStart(expr.info.clone()));
         }
 
         match path.kind {
@@ -1011,7 +1012,10 @@ impl Intrinsic {
                     let scope = context.scope().clone();
                     let journal = context.journal_mut().as_mut().unwrap();
                     journal.commit();
-                    journal.push_op(JournalOp::FnEnd(scope.into()));
+                    journal.push_op(JournalOp::FnEnd(
+                      expr.info.clone(),
+                      scope.into(),
+                    ));
                   }
                 }
 

--- a/stack-core/src/lexer.rs
+++ b/stack-core/src/lexer.rs
@@ -251,7 +251,7 @@ impl Lexer {
           | 'a'..='z'
           | 'A'..='Z' => state = State::Symbol,
           // TODO: Square brackets should be checked in the parsing step.
-          ' ' | '\n' | '\t' | '\r' | '[' | ']' => start = self.cursor + c_len,
+          ' ' | '\n' | '\t' | '\r' => start = self.cursor + c_len,
           _ => state = State::Invalid,
         },
         State::Invalid => match c {

--- a/stack-debugger/src/lib.rs
+++ b/stack-debugger/src/lib.rs
@@ -151,11 +151,11 @@ pub fn paint_op(op: &JournalOp, layout_job: &mut LayoutJob) {
       layout_job,
     ),
     JournalOp::SCall(expr) => append_to_job(
-      RichText::new(format!("{}", string_with_quotes(expr))).color(yellow),
+      RichText::new(string_with_quotes(expr)).color(yellow),
       layout_job,
     ),
     JournalOp::FnCall(expr) => append_to_job(
-      RichText::new(format!("{}", string_with_quotes(expr))).color(yellow),
+      RichText::new(string_with_quotes(expr)).color(yellow),
       layout_job,
     ),
     JournalOp::Push(expr) => append_to_job(

--- a/stack-debugger/src/lib.rs
+++ b/stack-debugger/src/lib.rs
@@ -166,10 +166,10 @@ pub fn paint_op(op: &JournalOp, layout_job: &mut LayoutJob) {
       RichText::new(format!("pop({})", string_with_quotes(expr))).color(red),
       layout_job,
     ),
-    JournalOp::ScopedFnStart(_) => {
+    JournalOp::ScopedFnStart(..) => {
       append_to_job(RichText::new("fn start"), layout_job);
     }
-    JournalOp::ScopelessFnStart => {
+    JournalOp::ScopelessFnStart(..) => {
       append_to_job(RichText::new("fn! start"), layout_job);
     }
     JournalOp::FnEnd(..) => {


### PR DESCRIPTION
Ending up on a "fn start" or the two other function marker ops wouldn't include any debug info for the Expr that they belong to, so the file viewer in the debugger would go blank.

I added a field to the ops that includes the debug info so that the debugger can properly display the expr when a function is instantiated.